### PR TITLE
Fix saving of buffer size and step size in settings dialog

### DIFF
--- a/dialogs/tartinisettingsdialog.cpp
+++ b/dialogs/tartinisettingsdialog.cpp
@@ -72,7 +72,7 @@ void TartiniSettingsDialog::loadSetting( QObject * p_object
     }
     else if(l_class_name == "QSpinBox")
     {
-        ((QSpinBox*)p_object)->setValue(g_data->getSettingsBoolValue(l_full_key));
+        ((QSpinBox*)p_object)->setValue(g_data->getSettingsIntValue(l_full_key));
     }
     else if(l_class_name == "QFrame")
     {


### PR DESCRIPTION
- buffer size and step size were being saved as Bool instead of Int
- this caused buffer size and step size to be set to 1ms
- this caused an assertion failure in NoteData::addVibratoData()