### PR TITLE
Make zoom wheels in Pitch Contour panel responsive to the mouse

### DIFF
--- a/widgets/freq/freqview.cpp
+++ b/widgets/freq/freqview.cpp
@@ -88,6 +88,7 @@ FreqView::FreqView( int p_view_id
     m_freq_wheel_Y->setSingleStep(0.001);
     // Use 1000 value for multiplicator so that PageStep has size 1
     m_freq_wheel_Y->setPageStepCount(1000);
+    m_freq_wheel_Y->setMass(0.1);
 #else
     m_freq_wheel_Y->setRange(1.6, 5.0, 0.001, 1);
 #endif // QWT_VERSION >= 0x060000
@@ -131,6 +132,7 @@ FreqView::FreqView( int p_view_id
     m_amplitude_wheel_Y->setSingleStep(0.01);
     // Use 100 value for multiplicator so that PageStep has size 1
     m_amplitude_wheel_Y->setPageStepCount(100);
+    m_amplitude_wheel_Y->setMass(0.1);
 #else
     m_amplitude_wheel_Y->setRange(0.2, 1.00, 0.01, 1);
 #endif // QWT_VERSION >= 0x060000
@@ -175,6 +177,7 @@ FreqView::FreqView( int p_view_id
     m_freq_wheel_X->setSingleStep(0.001);
     // Use 1000 value for multiplicator so that PageStep has size 1
     m_freq_wheel_X->setPageStepCount(1000);
+    m_freq_wheel_X->setMass(0.1);
 #else
     m_freq_wheel_X->setRange(0.5, 9.0, 0.001, 1);
 #endif // QWT_VERSION >= 0x060000
@@ -208,11 +211,15 @@ FreqView::FreqView( int p_view_id
 
     connect(&l_view, SIGNAL(viewBottomChanged(double)), m_freq_scroll_bar, SLOT(setValue(double)));
     connect(m_freq_wheel_Y, SIGNAL(valueChanged(double)), &l_view, SLOT(setZoomFactorY(double)));
-    connect(&l_view, SIGNAL(logZoomYChanged(double)), m_freq_wheel_Y, SLOT(setValue(double)));
+    // Connecting the wheel widget to the view and the view back to the wheel makes the wheel unresponsive.
+    // Setting the value on the wheel interrupts the curerent interaction with the mouse, so the wheel only advances one tick.
+    // connect(&l_view, SIGNAL(logZoomYChanged(double)), m_freq_wheel_Y, SLOT(setValue(double)));
 
     //horizontal
     connect(m_freq_wheel_X, SIGNAL(valueChanged(double)), &l_view, SLOT(setZoomFactorX(double)));
-    connect(&l_view, SIGNAL(logZoomXChanged(double)), m_freq_wheel_X, SLOT(setValue(double)));
+    // Connecting the wheel widget to the view and the view back to the wheel makes the wheel unresponsive.
+    // Setting the value on the wheel interrupts the curerent interaction with the mouse, so the wheel only advances one tick.
+    // connect(&l_view, SIGNAL(logZoomXChanged(double)), m_freq_wheel_X, SLOT(setValue(double)));
     connect(m_amplitude_wheel_Y, SIGNAL(valueChanged(double)), m_amplitude_widget, SLOT(setRange(double)));
     connect(m_amplitude_wheel_Y, SIGNAL(valueChanged(double)), m_amplitude_widget, SLOT(update()));
 
@@ -220,7 +227,9 @@ FreqView::FreqView( int p_view_id
     connect(m_amplitude_scroll_bar, SIGNAL(sliderMoved(double)), m_amplitude_widget, SLOT(update()));
 
     connect(m_amplitude_widget, SIGNAL(rangeChanged(double)), this, SLOT(setAmplitudeZoom(double)));
-    connect(m_amplitude_widget, SIGNAL(rangeChanged(double)), m_amplitude_wheel_Y, SLOT(setValue(double)));
+    // Connecting the wheel widget to the view and the view back to the wheel makes the wheel unresponsive.
+    // Setting the value on the wheel interrupts the curerent interaction with the mouse, so the wheel only advances one tick.
+    // connect(m_amplitude_widget, SIGNAL(rangeChanged(double)), m_amplitude_wheel_Y, SLOT(setValue(double)));
     connect(m_amplitude_widget, SIGNAL(offsetChanged(double)), m_amplitude_scroll_bar, SLOT(setValue(double)));
 
     //make the widgets get updated when the view changes

--- a/widgets/hbubble/hbubbleview.cpp
+++ b/widgets/hbubble/hbubbleview.cpp
@@ -65,6 +65,7 @@ HBubbleView::HBubbleView( int p_view_id
     l_harmonics_wheel->setRange(1, 40);
     l_harmonics_wheel->setSingleStep(1);
     l_harmonics_wheel->setPageStepCount(1);
+    l_harmonics_wheel->setMass(0.1);
 #else
     l_harmonics_wheel->setRange(1, 40, 1, 1);
 #endif // QWT_VERSION >= 0x060000
@@ -82,6 +83,7 @@ HBubbleView::HBubbleView( int p_view_id
     l_window_size_wheel->setSingleStep(2);
     // Sould be 0.5 but put to 1 because 0 zero value disable page stepping
     l_window_size_wheel->setPageStepCount(1);
+    l_window_size_wheel->setMass(0.1);
 #else
     l_window_size_wheel->setRange(32, 1024, 2, 1);
 #endif // QWT_VERSION >= 0x060000

--- a/widgets/hcircle/hcircleview.cpp
+++ b/widgets/hcircle/hcircleview.cpp
@@ -66,6 +66,7 @@ HCircleView::HCircleView( int p_view_id
     l_zoom_wheel->setSingleStep(0.001);
     // Multiplicator value is 1000 = 1 / 0.001
     l_zoom_wheel->setPageStepCount(1000);
+    l_zoom_wheel->setMass(0.1);
 #else
     l_zoom_wheel->setRange(0.001, 0.1, 0.001, 1);
 #endif // QWT_VERSION >= 0x060000
@@ -82,6 +83,7 @@ HCircleView::HCircleView( int p_view_id
     l_lowest_value_wheel->setSingleStep(0.01);
     // Multiplicator value is 100 = 1 / 0.01
     l_lowest_value_wheel->setPageStepCount(100);
+    l_lowest_value_wheel->setMass(0.1);
 #else
     l_lowest_value_wheel->setRange(-160, 10, 0.01, 1);
 #endif // QWT_VERSION >= 0x060000
@@ -99,6 +101,7 @@ HCircleView::HCircleView( int p_view_id
     l_threshold_wheel->setSingleStep(0.01);
     // Multiplicator value is 100 = 1 / 0.01
     l_threshold_wheel->setPageStepCount(100);
+    l_threshold_wheel->setMass(0.1);
 #else
     l_threshold_wheel->setRange(-160, 10, 0.01, 1);
 #endif // QWT_VERSION >= 0x060000

--- a/widgets/hstack/hstackview.cpp
+++ b/widgets/hstack/hstackview.cpp
@@ -65,6 +65,7 @@ HStackView::HStackView( int p_view_id
     l_db_range_wheel->setSingleStep(0.1);
     // Multiplicator value is 1000 = 100 * 0.1
     l_db_range_wheel->setPageStepCount(1000);
+    l_db_range_wheel->setMass(0.1);
 #else
     l_db_range_wheel->setRange(5, 160.0, 0.1, 100);
 #endif // QWT_VERSION >= 0x060000
@@ -81,6 +82,7 @@ HStackView::HStackView( int p_view_id
     l_window_size_wheel->setSingleStep(2);
     // Sould be 0.5 but put to 1 because 0 zero value disable page stepping
     l_window_size_wheel->setPageStepCount(1);
+    l_window_size_wheel->setMass(0.1);
 #else
     l_window_size_wheel->setRange(32, 1024, 2, 1);
 #endif // QWT_VERSION >= 0x060000

--- a/widgets/htrack/htrackview.cpp
+++ b/widgets/htrack/htrackview.cpp
@@ -63,6 +63,7 @@ HTrackView::HTrackView( int p_view_ID
     m_rotate_X_wheel->setSingleStep(0.1);
     // Multiplicator value is 10 = 1 / 0.1
     m_rotate_X_wheel->setPageStepCount(10);
+    m_rotate_X_wheel->setMass(0.1);
 #else
     m_rotate_X_wheel->setRange(-180, 180, 0.1, 1);
 #endif // QWT_VERSION >= 0x060000
@@ -76,6 +77,7 @@ HTrackView::HTrackView( int p_view_ID
     m_rotate_Y_wheel->setSingleStep(0.1);
     // Multiplicator value is 10 = 1 / 0.1
     m_rotate_Y_wheel->setPageStepCount(10);
+    m_rotate_Y_wheel->setMass(0.1);
 #else
     m_rotate_Y_wheel->setRange(-90, 0, 0.1, 1);
 #endif // QWT_VERSION >= 0x060000
@@ -88,6 +90,7 @@ HTrackView::HTrackView( int p_view_ID
     m_distance_wheel->setSingleStep(10);
     // Multiplicator value is 2 = 20 / 10
     m_distance_wheel->setPageStepCount(2);
+    m_distance_wheel->setMass(0.1);
 #else
     m_distance_wheel->setRange(100, 5000, 10, 20);
 #endif // QWT_VERSION >= 0x060000
@@ -120,13 +123,19 @@ HTrackView::HTrackView( int p_view_ID
     connect(m_peak_threshold_slider, SIGNAL(valueChanged(int)), this, SLOT(setPeakThreshold(int)));
     connect(m_rotate_Y_wheel, SIGNAL(valueChanged(double)), m_h_track_widget, SLOT(setViewAngleVertical(double)));
     connect(m_rotate_Y_wheel, SIGNAL(valueChanged(double)), m_h_track_widget, SLOT(update()));
-    connect(m_h_track_widget, SIGNAL(viewAngleVerticalChanged(double)), m_rotate_Y_wheel, SLOT(setValue(double)));
+    // Connecting the wheel widget to the view and the view back to the wheel makes the wheel unresponsive.
+    // Setting the value on the wheel interrupts the curerent interaction with the mouse, so the wheel only advances one tick.
+    // connect(m_h_track_widget, SIGNAL(viewAngleVerticalChanged(double)), m_rotate_Y_wheel, SLOT(setValue(double)));
     connect(m_distance_wheel, SIGNAL(valueChanged(double)), m_h_track_widget, SLOT(setDistanceAway(double)));
     connect(m_distance_wheel, SIGNAL(valueChanged(double)), m_h_track_widget, SLOT(update()));
-    connect(m_h_track_widget, SIGNAL(distanceAwayChanged(double)), m_distance_wheel, SLOT(setValue(double)));
+    // Connecting the wheel widget to the view and the view back to the wheel makes the wheel unresponsive.
+    // Setting the value on the wheel interrupts the curerent interaction with the mouse, so the wheel only advances one tick.
+    // connect(m_h_track_widget, SIGNAL(distanceAwayChanged(double)), m_distance_wheel, SLOT(setValue(double)));
     connect(m_rotate_X_wheel, SIGNAL(valueChanged(double)), m_h_track_widget, SLOT(setViewAngleHorizontal(double)));
     connect(m_rotate_X_wheel, SIGNAL(valueChanged(double)), m_h_track_widget, SLOT(update()));
-    connect(m_h_track_widget, SIGNAL(viewAngleHorizontalChanged(double)), m_rotate_X_wheel, SLOT(setValue(double)));
+    // Connecting the wheel widget to the view and the view back to the wheel makes the wheel unresponsive.
+    // Setting the value on the wheel interrupts the curerent interaction with the mouse, so the wheel only advances one tick.
+    // connect(m_h_track_widget, SIGNAL(viewAngleHorizontalChanged(double)), m_rotate_X_wheel, SLOT(setValue(double)));
     connect(l_home_button, SIGNAL(clicked()), m_h_track_widget, SLOT(home()));
 }
 

--- a/widgets/score/scoreview.cpp
+++ b/widgets/score/scoreview.cpp
@@ -55,6 +55,7 @@ ScoreView::ScoreView(int p_view_id
     l_scale_wheel_Y->setSingleStep(0.1);
     // Multiplicator value is 100 = 1 / 0.01
     l_scale_wheel_Y->setPageStepCount(10);
+    l_scale_wheel_Y->setMass(0.1);
 #else
     l_scale_wheel_Y->setRange(1.0, 30.0, 0.1, 1);
 #endif // QWT_VERSION >= 0x060000
@@ -73,6 +74,7 @@ ScoreView::ScoreView(int p_view_id
     l_scale_wheel_X->setRange(1.0, 100.0);
     l_scale_wheel_X->setSingleStep(1.1);
     l_scale_wheel_X->setPageStepCount(1);
+    l_scale_wheel_X->setMass(0.1);
 #else
     l_scale_wheel_X->setRange(1.0, 100.0, 1.1, 1);
 #endif // QWT_VERSION >= 0x060000

--- a/widgets/vibrato/vibratoview.cpp
+++ b/widgets/vibrato/vibratoview.cpp
@@ -250,6 +250,7 @@ VibratoView::VibratoView(int p_view_ID
     l_zoom_wheel_V->setSingleStep(0.1);
     // Multiplicator value is 10 = 1 / 0.1
     l_zoom_wheel_V->setPageStepCount(10);
+    l_zoom_wheel_V->setMass(0.1);
 #else
     l_zoom_wheel_V->setRange(0.3, 25.0, 0.1, 1);
 #endif // QWT_VERSION >= 0x060000
@@ -288,6 +289,7 @@ VibratoView::VibratoView(int p_view_ID
     l_zoom_wheel_H->setRange(1, 100);
     l_zoom_wheel_H->setSingleStep(1);
     l_zoom_wheel_H->setPageStepCount(1);
+    l_zoom_wheel_H->setMass(0.1);
 #else
     l_zoom_wheel_H->setRange(1, 100, 1, 1);
 #endif // QWT_VERSION >= 0x060000

--- a/widgets/wave/waveview.cpp
+++ b/widgets/wave/waveview.cpp
@@ -51,6 +51,7 @@ WaveView::WaveView(int p_view_ID
     l_freq_wheel_Y->setSingleStep(0.1);
     // Multiplicator value is 10 = 1 / 0.1
     l_freq_wheel_Y->setPageStepCount(10);
+    l_freq_wheel_Y->setMass(0.1);
 #else
     l_freq_wheel_Y->setRange(1.0, 20.0, 0.1, 1);
 #endif // QWT_VERSION >= 0x060000


### PR DESCRIPTION
- At least on Mac, the "zoom" wheels in the "Pitch Contour" panel are not responsive.  They move at most one tick when you click and drag.
- The issue is that the value of the wheel is connected to the zoom level of the view, but the zoom level of the view is also connected back to the value of the wheel.
- When the wheel is rotated one tick, this results in the wheel value being set, which interrupts the current mouse interaction and prevents the user from rotating the wheel any further.
- The simple fix is to not modify the wheel position when the zoom level is changed via a different interaction (such as by using Shift-Mouse-Scroll in the main panel).
- Users who only use the wheel widget will not notice an issue.
- Users who only use Shift-Mouse-Scroll will not notice an issue.
- Users who use *both* methods to scroll may notice that the wheel widget is off after using Shift-Mouse-Scroll.
- A better fix would be to only update the wheel position if the change in zoom level was caused by a source other than the wheel widget.
- Also set a small "mass" value on all of the wheel widgets to make them easier to use and more "modern" feeling.