### PR TITLE
Add assert in MyTransforms::calculateAnalysisData()

### DIFF
--- a/general/mytransforms.cpp
+++ b/general/mytransforms.cpp
@@ -494,6 +494,7 @@ void MyTransforms::calculateAnalysisData(/*float *input, */
             //calc the l_period_diff
             if(p_chunk > 0)
             {
+                myassert(l_prev_analysis_data);
                 float l_prev_period = l_prev_analysis_data->getHighestCorrelationIndex() != -1 ? l_prev_analysis_data->getPeriodEstimatesAt(l_prev_analysis_data->getHighestCorrelationIndex()) : 0;
                 l_period_diff = l_analysis_data.searchClosestPeriodEstimates(l_prev_period) - l_prev_period;
                 if(absolute(l_period_diff) > 8.0f)


### PR DESCRIPTION
The clang static analyzer reported this possible null pointer use:

```
tartini/general/mytransforms.cpp:497:39: Called C++ object pointer is null
tartini/general/mytransforms.cpp:401:5: Assuming 'p_channel' is non-null
tartini/general/mytransforms.cpp:402:5: Assuming the condition is false
tartini/general/mytransforms.cpp:404:5: 'l_prev_analysis_data' initialized here
tartini/general/mytransforms.cpp:406:31: Assuming field 'm_equal_loudness' is false
tartini/general/mytransforms.cpp:414:8: Assuming the condition is true
tartini/general/mytransforms.cpp:414:40: Assuming the condition is true
tartini/general/mytransforms.cpp:419:12: Assuming the condition is false
tartini/general/mytransforms.cpp:454:12: Assuming 'l_prev_analysis_data' is null
tartini/general/mytransforms.cpp:464:12: Assuming the condition is false
tartini/general/mytransforms.cpp:472:79: Loop body executed 0 times
tartini/general/mytransforms.cpp:486:12: Assuming the condition is false
tartini/general/mytransforms.cpp:495:16: Assuming 'p_chunk' is > 0
tartini/general/mytransforms.cpp:497:39: Called C++ object pointer is null
```

This fix seems safe, since the code already handles the case where `l_prev_analysis_data->getHighestCorrelationIndex() == -1`.

With this change, the code would handle the case of `l_prev_analysis_data==NULL` in the same way.