### PR TITLE
Add assert in AudioThread::doStuff()

### DIFF
--- a/sound/audio_thread.cpp
+++ b/sound/audio_thread.cpp
@@ -176,6 +176,7 @@ int AudioThread::doStuff()
     //This is the main block of code for reading or write the next chunk to the soundcard or file
     if(g_data->getSoundMode() == SOUND_PLAY)
     {
+        myassert(m_play_sound_file);
         if(!m_play_sound_file->playChunk())
         {
             //end of file


### PR DESCRIPTION
Add an assert to suppress this warning found by the clang static analyzer:

```
tartini/sound/audio_thread.cpp:180:13: Called C++ object pointer is null
tartini/sound/audio_thread.cpp:103:8: Assuming the condition is false
tartini/sound/audio_thread.cpp:113:11: Assuming field 'm_stopping' is false
tartini/sound/audio_thread.cpp:113:11: Entering loop body
tartini/sound/audio_thread.cpp:115:12: Calling 'AudioThread::doStuff'
tartini/sound/audio_thread.cpp:148:1: Entered call from 'AudioThread::run'
tartini/sound/audio_thread.cpp:157:8: Assuming field 'm_play_sound_file' is null
tartini/sound/audio_thread.cpp:157:30: Assuming field 'm_rec_sound_file' is non-null
tartini/sound/audio_thread.cpp:177:8: Assuming the condition is true
tartini/sound/audio_thread.cpp:180:13: Called C++ object pointer is null
```