### PR TITLE
Don't crash when pressing ESC key on Mac

### DIFF
--- a/widgets/mainwindow/mainwindow.cpp
+++ b/widgets/mainwindow/mainwindow.cpp
@@ -616,7 +616,7 @@ void MainWindow::keyPressEvent (QKeyEvent * p_event)
 #ifdef MYDEBUG
         case Qt::Key_Escape:
             g_data->stopAndWaitAudioThread();
-            qApp->closeAllWindows();
+            close();
         break;
 #endif // MYDEBUG
         case Qt::Key_Left:


### PR DESCRIPTION
Using `MainWindow::close()` instead of `qApp->closeAllWindows()` avoids a crash on the Mac.