### PR TITLE
Fixes for DEBUG_PRINTF

### DIFF
--- a/general/mytransforms.cpp
+++ b/general/mytransforms.cpp
@@ -101,9 +101,9 @@ void MyTransforms::init( int p_n
     m_hanning_scalar /= 2;
 
     m_fast_smooth = new fast_smooth(m_n / 8);
-#ifdef PRINTF_DEBUG
-    printf("fast_smooth size = %d\n", n / 8);
-#endif // PRINTF_DEBUG
+#ifdef DEBUG_PRINTF
+    printf("m_fast_smooth size = %d\n", m_n / 8);
+#endif // DEBUG_PRINTF
     m_been_init = true;
 }
 
@@ -590,10 +590,6 @@ void MyTransforms::calculateAnalysisData(/*float *input, */
 //------------------------------------------------------------------------------
 float MyTransforms::get_fine_clarity_measure(double p_period)
 {
-#ifdef PRINTF_DEBUG
-    printf("%f, ", analysisData.m_period_estimates[choosenMaxIndex]);
-    printf("%f, ", analysisData.m_period_estimates_amp[choosenMaxIndex]);
-#endif // PRINTF_DEBUG
     int l_temp_N = m_n - int(ceil(p_period));
     float * l_temp_data = new float[l_temp_N];
     float l_big_sum = 0;
@@ -610,9 +606,9 @@ float MyTransforms::get_fine_clarity_measure(double p_period)
         l_corr_sum += m_data_time[l_j] * l_temp_data[l_j];
     }
     l_match_min = (2.0 * l_corr_sum) / l_big_sum;
-#ifdef PRINTF_DEBUG
+#ifdef DEBUG_PRINTF
     printf("%f, ", l_match_min);
-#endif // PRINTF_DEBUG
+#endif // DEBUG_PRINTF
     for(int l_j = 0; l_j < l_temp_N - l_dN; l_j++)
     {
         l_big_sum -= sq(m_data_time[l_j]) + sq(l_temp_data[l_j]);
@@ -625,9 +621,9 @@ float MyTransforms::get_fine_clarity_measure(double p_period)
             l_match_min = l_match_val;
         }
     }
-#ifdef PRINTF_DEBUG
+#ifdef DEBUG_PRINTF
     printf("%f\n", l_match_min);
-#endif // PRINTF_DEBUG
+#endif // DEBUG_PRINTF
     delete[] l_temp_data;
 
     return l_match_min;
@@ -721,9 +717,9 @@ double MyTransforms::get_max_note_change( float * p_input
             l_err[l_i] += sq(p_input[l_j] - p_input[l_j2]);
         }
     }
-#ifdef PRINTF_DEBUG
-    printf("subwindow_size=%d, num=%d, period=%lf\n", subwindow_size, num, period);
-#endif // PRINTF_DEBUG
+#ifdef DEBUG_PRINTF
+    printf("l_subwindow_size=%d, l_num=%d, p_period=%lf\n", l_subwindow_size, l_num, p_period);
+#endif // DEBUG_PRINTF
     /*matlab code
       for j = 1:(num-1)
         for i = 1:ln
@@ -782,17 +778,17 @@ double MyTransforms::get_max_note_change( float * p_input
     for(l_j = 0; l_j < l_num - 2; l_j++)
     {
         l_smoothed_diff[l_j] = fabs(l_smoothed[l_j + 1] - l_smoothed[l_j]);
-#ifdef PRINTF_DEBUG
-        printf("%f ", smoothed[j]);
-#endif // PRINTF_DEBUG
+#ifdef DEBUG_PRINTF
+        printf("%f ", l_smoothed[l_j]);
+#endif // DEBUG_PRINTF
         if(l_smoothed_diff[l_j] > l_smoothed_diff[l_max_pos])
         {
             l_max_pos = l_j;
         }
     }
-#ifdef PRINTF_DEBUG
-    printf("\nsmooted_diff=%f\n", smoothed_diff[l_max_pos]);
-#endif // PRINTF_DEBUG
+#ifdef DEBUG_PRINTF
+    printf("\l_smoothed_diff=%f\n", l_smoothed_diff[l_max_pos]);
+#endif // DEBUG_PRINTF
     double l_ret = l_smoothed_diff[l_max_pos] / p_period * double(m_rate) * double(l_subwindow_size) / 10000.0;
     return l_ret;
 }
@@ -880,9 +876,9 @@ void MyTransforms::doChannelDataFFT( Channel * p_channel
         p_channel->get_fft_data1()[0] = g_data->dBFloor();
     }
 
-#ifdef PRINTF_DEBUG
+#ifdef DEBUG_PRINTF
     printf("n = %d, fff = %f\n", l_n_div_2, *std::max_element(p_channel->get_fft_data2().begin(), p_channel->get_fft_data2().end()));
-#endif // PRINTF_DEBUG
+#endif // DEBUG_PRINTF
 
     if(g_data->analysisType() == MPM_MODIFIED_CEPSTRUM)
     {
@@ -943,9 +939,9 @@ void MyTransforms::doHarmonicAnalysis( float * p_input
     double l_num_periods_use = l_num_periods_fit - 1.0;
     int l_int_num_periods_use = int(l_num_periods_use);
     double l_center_X = float(m_n) / 2.0;
-#ifdef PRINTF_DEBUG
+#ifdef DEBUG_PRINTF
     printf("l_int_num_periods_use = %d\n", l_int_num_periods_use);
-#endif // PRINTF_DEBUG
+#endif // DEBUG_PRINTF
     //do left
     double l_start = l_center_X - (l_num_periods_fit / 2.0) * p_period;
     double l_length = (l_num_periods_use) * p_period;
@@ -953,14 +949,14 @@ void MyTransforms::doHarmonicAnalysis( float * p_input
     applyHanningWindow(m_data_time);
     fftwf_execute(m_plan_data_time_2_FFT);
     calcHarmonicAmpPhase(m_harmonics_amp_left, m_harmonics_phase_left, l_int_num_periods_use);
-#ifdef PRINTF_DEBUG
+#ifdef DEBUG_PRINTF
     printf("left\n");
     for(int jj = 0; jj < 6; jj++)
     {
         printf("[%d %lf %lf]", jj, m_harmonics_amp_left[jj], m_harmonics_phase_left[jj]);
     }
     printf("\n");
-#endif // PRINTF_DEBUG
+#endif // DEBUG_PRINTF
   
     //do center
     l_start += p_period / 2.0;
@@ -968,14 +964,14 @@ void MyTransforms::doHarmonicAnalysis( float * p_input
     applyHanningWindow(m_data_time);
     fftwf_execute(m_plan_data_time_2_FFT);
     calcHarmonicAmpPhase(m_harmonics_amp_center, m_harmonics_phase_center, l_int_num_periods_use);
-#ifdef PRINTF_DEBUG
+#ifdef DEBUG_PRINTF
     printf("centre\n");
     for(int jj = 0; jj < 6; jj++)
     {
         printf("[%d %lf %lf]", jj, m_harmonics_amp_center[jj], m_harmonics_phase_center[jj]);
     }
     printf("\n");
-#endif // PRINTF_DEBUG
+#endif // DEBUG_PRINTF
   
     //do right
     l_start += p_period / 2.0;
@@ -983,14 +979,14 @@ void MyTransforms::doHarmonicAnalysis( float * p_input
     applyHanningWindow(m_data_time);
     fftwf_execute(m_plan_data_time_2_FFT);
     calcHarmonicAmpPhase(m_harmonics_amp_right, m_harmonics_phase_right, l_int_num_periods_use);
-#ifdef PRINTF_DEBUG
+#ifdef DEBUG_PRINTF
     printf("right\n");
     for(int jj = 0; jj < 6; jj++)
     {
         printf("[%d %lf %lf]", jj, m_harmonics_amp_right[jj], m_harmonics_phase_right[jj]);
     }
     printf("\n");
-#endif // PRINTF_DEBUG
+#endif // DEBUG_PRINTF
   
     double l_freq = m_rate / p_period;
   

--- a/sound/channel.cpp
+++ b/sound/channel.cpp
@@ -607,7 +607,7 @@ bool Channel::isNoteChanging(int p_chunk)
     if(l_num_chunks > 1 && l_diff > 2)
     { //if jumping to fast anywhere then note is changing
 #ifdef DEBUG_PRINTF
-        printf("numChunks=%d\n", getCurrentNote()->numChunks());
+        printf("numChunks=%d\n", l_num_chunks);
         printf("analysisData->pitch=%f, ", l_analysis_data->getPitch());
         printf("prevData->shortTermMean=%f\n", l_previous_data->getShortTermMean());
 #endif // DEBUG_PRINTF

--- a/sound/soundfile.cpp
+++ b/sound/soundfile.cpp
@@ -159,9 +159,9 @@ QString SoundFile::getNextTempFilename() const
         std::stringstream l_stream;
         l_stream << "temp" << std::setfill('0') << std::setw(3) << l_index << ".wav";
         l_file_name = QString::fromStdString(l_stream.str());
-#ifdef PRINTF_DEBUG
-        printf("trying %s\n", fileName.latin1());
-#endif // PRINTF_DEBUG
+#ifdef DEBUG_PRINTF
+        printf("trying %s\n", l_file_name.toStdString().c_str());
+#endif // DEBUG_PRINTF
         l_file_info.setFile(l_dir, l_file_name);
         if(l_file_info.exists())
         {
@@ -306,10 +306,10 @@ bool SoundFile::openWrite( const char * p_filename
         g_main_window->menuPreferences();
         return false;
     }
-#ifdef PRINTF_DEBUG
-    printf("in_channels = %d\n", g_data->in_channels);
-    printf("stream->channels=%d\n", stream->channels);
-#endif // PRINTF_DEBUG
+#ifdef DEBUG_PRINTF
+    printf("in_channels = %zu\n", g_data->getChannelsSize());
+    printf("m_stream->channels=%d\n", m_stream->get_channels());
+#endif // DEBUG_PRINTF
 
     m_channels.resize(m_stream->get_channels());
     fprintf(stderr, "channels = %d\n", numChannels());
@@ -393,13 +393,6 @@ void SoundFile::applyEqualLoudnessFilter(int p_n)
     int l_j;
     for(l_c = 0; l_c < numChannels(); l_c++)
     {
-#ifdef PRINTF_DEBUG
-        printf("before: %f == %f\n", channels(l_c)->filterStateX1, channels(c)->m_high_pass_filter->m_x[0]);
-        printf("before: %f == %f\n", channels(l_c)->filterStateX2, channels(c)->m_high_pass_filter->m_x[1]);
-        printf("before: %f == %f\n", channels(l_c)->filterStateY1, channels(c)->m_high_pass_filter->m_y[0]);
-        printf("before: %f == %f\n", channels(l_c)->filterStateY2, channels(c)->m_high_pass_filter->m_y[1]);
-#endif // PRINTF_DEBUG
-
         m_channels(l_c)->apply_highpass_filter(m_temp_window_buffer[l_c], m_temp_window_buffer_filtered[l_c], p_n);
         for(l_j = 0; l_j < p_n; l_j++)
         {
@@ -666,9 +659,9 @@ void SoundFile::preProcess()
     while(readChunk(framesPerChunk()) == framesPerChunk())
     {
         // put data in channels
-#ifdef PRINTF_DEBUG
-        printf("pos = %d\n", stream->pos);
-#endif // PRINTF_DEBUG
+#ifdef DEBUG_PRINTF
+        printf("pos = %d\n", m_stream->pos());
+#endif // DEBUG_PRINTF
         l_frame_count++;
 
         if(l_frame_count % l_update_interval == 0)
@@ -678,10 +671,10 @@ void SoundFile::preProcess()
             l_frame_count = 1;
         }
     }
-#ifdef PRINTF_DEBUG
+#ifdef DEBUG_PRINTF
     printf("totalChunks=%d\n", totalChunks());
     printf("currentChunks=%d\n", currentChunk());
-#endif // PRINTF_DEBUG
+#endif // DEBUG_PRINTF
     m_filtered_stream->close();
     m_filtered_stream->open_read(m_filtered_filename);
     jumpToChunk(0);
@@ -694,9 +687,6 @@ void SoundFile::preProcess()
 
     g_data->setDoingActiveAnalysis(false);
     m_first_time_through = false;
-#ifdef PRINTF_DEBUG
-    printf("freqLookup.size()=%d\n", channels(0)->freqLookup.size());
-#endif // PRINTF_DEBUG
 }
 
 //------------------------------------------------------------------------------

--- a/sound/wave_stream.cpp
+++ b/sound/wave_stream.cpp
@@ -165,9 +165,9 @@ int WaveStream::read_header()
             }
         }
     }
-#ifdef PRINTF_DEBUG
-    printf("header_length=%d\n", m_header_length);
-#endif // PRINTF_DEBUG
+#ifdef DEBUG_PRINTF
+    printf("m_header_length=%d\n", m_header_length);
+#endif // DEBUG_PRINTF
     set_total_frames(l_len / frame_size());
 
     return 0;


### PR DESCRIPTION
- Update debug print statements to use new variable names
- Standardize on `DEBUG_PRINTF` (vs. `PRINTF_DEBUG` in some files)
- Fix crash in `sound/channel.cpp` when debug printing is enabled
- Removed some old debug print statements that were too old to fix