### PR TITLE
Make all views update consistently

### DIFF
--- a/global/view.cpp
+++ b/global/view.cpp
@@ -173,6 +173,9 @@ void View::setCurrentTime(double p_x)
         emit currentTimeChanged(p_x);
         emit timeViewRangeChanged(viewLeft(), viewRight());
         emit viewChanged();
+        
+        // Update all views (both slow and fast ones).
+        doUpdate();
     }
 }
 

--- a/widgets/mainwindow/mainwindow.cpp
+++ b/widgets/mainwindow/mainwindow.cpp
@@ -426,7 +426,8 @@ MainWindow::MainWindow()
     m_time_slider->setMinimumWidth(200);
     m_time_slider->setWhatsThis("Drag the time slider to move back and forward through the sound file");
     connect(m_time_slider, SIGNAL(sliderMoved(double)), g_data, SLOT(updateActiveChunkTime(double)));
-    connect(m_time_slider, SIGNAL(sliderMoved(double)), &l_view, SLOT(doSlowUpdate()));
+    // This is no longer needed, since View::setCurrentTime() now calls doUpdate() to update all views (fast and slow ones).
+    // connect(m_time_slider, SIGNAL(sliderMoved(double)), &l_view, SLOT(doSlowUpdate()));
     connect(&l_view, SIGNAL(onSlowUpdate(double)), m_time_slider, SLOT(setValue(double)));
     connect(g_data, SIGNAL(timeRangeChanged(double, double)), this, SLOT(setTimeRange(double, double)));
     l_time_bar_dock->addWidget(m_time_slider);

--- a/widgets/pitchcompass/pitchcompassview.cpp
+++ b/widgets/pitchcompass/pitchcompassview.cpp
@@ -27,7 +27,7 @@ PitchCompassView::PitchCompassView( int p_view_id
 : ViewWidget(p_view_id, p_parent)
 {
     m_pitch_compass_draw_widget = new PitchCompassDrawWidget(this, "compass", p_mode);
-    connect(&(g_data->getView()), SIGNAL(currentTimeChanged(double)), m_pitch_compass_draw_widget, SLOT(updateCompass(double)));
+    connect(&(g_data->getView()), SIGNAL(onFastUpdate(double)), m_pitch_compass_draw_widget, SLOT(updateCompass(double)));
     m_pitch_compass_draw_widget->show();
 }
 
@@ -47,7 +47,7 @@ void PitchCompassView::changeMode(int p_mode)
 {
     delete m_pitch_compass_draw_widget;
     m_pitch_compass_draw_widget = new PitchCompassDrawWidget(this, "compass", p_mode);
-    connect(&(g_data->getView()), SIGNAL(currentTimeChanged(double)), m_pitch_compass_draw_widget, SLOT(updateCompass(double)));
+    connect(&(g_data->getView()), SIGNAL(onFastUpdate(double)), m_pitch_compass_draw_widget, SLOT(updateCompass(double)));
 }
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
- In `View::setCurrentTime()` call `doUpdate()` so that all views get updated as you drag the "Pitch Contour" views left and right.
    + Previously, the "slow" views would not get updated.
    + Now update both slow and fast views when the time is changed.
- In `MainWindow`, no longer connect `m_time_slider` to `doSlowUpdate()`
    + This is no longer needed since it already updates the time, which now calls doUpdate().
- Make `PitchCompassView` update on the `onFastUpdate()` event rather than `currentTimeChanged()`.
    + This is consistent with other similar views, such as `PianoView`.
    + Now no views update based on `currentTimeChanged()`.