### PR TITLE
Replace all C-style casts with `static_cast<>`

### DIFF
--- a/dialogs/tartinisettingsdialog.cpp
+++ b/dialogs/tartinisettingsdialog.cpp
@@ -58,31 +58,31 @@ void TartiniSettingsDialog::loadSetting( QObject * p_object
     }
     else if(l_class_name == "QLineEdit")
     {
-         ((QLineEdit*)p_object)->setText(QString::fromStdString(g_data->getSettingsStringValue(l_full_key)));
+         static_cast<QLineEdit*>(p_object)->setText(QString::fromStdString(g_data->getSettingsStringValue(l_full_key)));
     }
     else if(l_class_name == "QComboBox")
     {
-         ((QComboBox*)p_object)->setCurrentIndex(((QComboBox*)p_object)->findText(QString::fromStdString(g_data->getSettingsStringValue(l_full_key))));
+         static_cast<QComboBox*>(p_object)->setCurrentIndex(static_cast<QComboBox*>(p_object)->findText(QString::fromStdString(g_data->getSettingsStringValue(l_full_key))));
     }
-    else if(l_class_name == "QPushButton" && ((QPushButton*)p_object)->isCheckable())
+    else if(l_class_name == "QPushButton" && static_cast<QPushButton*>(p_object)->isCheckable())
     {
-        ((QPushButton*)p_object)->setChecked(g_data->getSettingsBoolValue(l_full_key));
+        static_cast<QPushButton*>(p_object)->setChecked(g_data->getSettingsBoolValue(l_full_key));
     }
     else if(l_class_name == "QCheckBox")
     {
-         ((QCheckBox*)p_object)->setChecked(g_data->getSettingsBoolValue(l_full_key));
+         static_cast<QCheckBox*>(p_object)->setChecked(g_data->getSettingsBoolValue(l_full_key));
     }
     else if(l_class_name == "QSpinBox")
     {
-        ((QSpinBox*)p_object)->setValue(g_data->getSettingsIntValue(l_full_key));
+        static_cast<QSpinBox*>(p_object)->setValue(g_data->getSettingsIntValue(l_full_key));
     }
     else if(l_class_name == "QFrame")
     {
         QColor l_color;
         l_color.setNamedColor(QString::fromStdString(g_data->getSettingsStringValue(l_full_key)));
-        QPalette l_palette = ((QFrame*)p_object)->palette();
+        QPalette l_palette = static_cast<QFrame*>(p_object)->palette();
         l_palette.setColor(l_palette.currentColorGroup(),QPalette::Window,l_color);
-        ((QFrame*)p_object)->setPalette(l_palette);
+        static_cast<QFrame*>(p_object)->setPalette(l_palette);
     }
     else if("QVBoxLayout" != l_class_name &&
             "QHBoxLayout" != l_class_name &&
@@ -215,27 +215,27 @@ void TartiniSettingsDialog::saveSetting(QObject *p_object, const std::string  & 
     }
     else if(l_class_name == "QLineEdit")
     {
-        g_data->setSettingsValue(l_full_key, ((QLineEdit*)p_object)->text().toStdString());
+        g_data->setSettingsValue(l_full_key, static_cast<QLineEdit*>(p_object)->text().toStdString());
     }
     else if(l_class_name == "QComboBox")
     {
-        g_data->setSettingsValue(l_full_key, ((QComboBox*)p_object)->currentText().toStdString());
+        g_data->setSettingsValue(l_full_key, static_cast<QComboBox*>(p_object)->currentText().toStdString());
     }
-    else if(l_class_name == "QPushButton" && ((QPushButton*)p_object)->isCheckable())
+    else if(l_class_name == "QPushButton" && static_cast<QPushButton*>(p_object)->isCheckable())
     {
-        g_data->setSettingsValue(l_full_key, ((QPushButton*)p_object)->isChecked());
+        g_data->setSettingsValue(l_full_key, static_cast<QPushButton*>(p_object)->isChecked());
     }
     else if(l_class_name == "QCheckBox")
     {
-        g_data->setSettingsValue(l_full_key, ((QCheckBox*)p_object)->isChecked());
+        g_data->setSettingsValue(l_full_key, static_cast<QCheckBox*>(p_object)->isChecked());
     }
     else if(l_class_name == "QSpinBox")
     {
-        g_data->setSettingsValue(l_full_key, ((QSpinBox*)p_object)->value());
+        g_data->setSettingsValue(l_full_key, static_cast<QSpinBox*>(p_object)->value());
     }
     else if(l_class_name == "QFrame")
     {
-        QColor l_color =  ((QFrame*)p_object)->palette().color(QPalette::Window);
+        QColor l_color =  static_cast<QFrame*>(p_object)->palette().color(QPalette::Window);
         g_data->setSettingsValue(l_full_key,l_color.name().toStdString());
     }
     else if("QVBoxLayout" != l_class_name &&

--- a/general/bspline.cpp
+++ b/general/bspline.cpp
@@ -27,7 +27,7 @@ inline float interpolate_linear( int p_len
                                , float p_x
                                )
 {
-    int l_x0 = (int)p_x;
+    int l_x0 = static_cast<int>(p_x);
     if(l_x0 >= 0 && l_x0 < p_len - 1)
     {
         float l_y0 = p_array[l_x0];

--- a/general/large_vector.hpp
+++ b/general/large_vector.hpp
@@ -66,7 +66,7 @@ void large_vector<T>::copyTo( T * p_dest
         std::copy(getBuffer(l_cur_buf).begin() + l_offset, getBuffer(l_cur_buf).end(), p_dest);
         p_dest += bufferSize() - l_offset;
         l_cur_buf++;
-        while(((unsigned int)(l_ending - p_dest)) > bufferSize())
+        while((static_cast<unsigned int>(l_ending - p_dest)) > bufferSize())
         {
             std::copy(getBuffer(l_cur_buf).begin(), getBuffer(l_cur_buf).end(), p_dest);
             p_dest += bufferSize();
@@ -96,7 +96,7 @@ void large_vector<T>::copyFrom( const T * p_src
         std::copy(p_src, p_src + (bufferSize() - l_offset), getBuffer(l_cur_buf).begin() + l_offset);
         p_src += bufferSize() - l_offset;
         l_cur_buf++;
-        while(((unsigned int)(l_ending - p_src)) > bufferSize())
+        while((static_cast<unsigned int>(l_ending - p_src)) > bufferSize())
         {
             std::copy(p_src, p_src + bufferSize(), getBuffer(l_cur_buf).begin());
             p_src += bufferSize();

--- a/general/music_key.cpp
+++ b/general/music_key.cpp
@@ -86,7 +86,7 @@ void MusicKey::setName(const char * p_name)
 //------------------------------------------------------------------------------
 int MusicKey::nearestNoteIndex(const double & p_x)const
 {
-    return (int)(binary_search_closest(m_note_offsets.begin(), m_note_offsets.end(), p_x) - m_note_offsets.begin());
+    return static_cast<int>(binary_search_closest(m_note_offsets.begin(), m_note_offsets.end(), p_x) - m_note_offsets.begin());
 }
 
 //------------------------------------------------------------------------------
@@ -104,19 +104,19 @@ double MusicKey::nearestNoteDistance(const double & p_x)const
 
 std::vector<MusicKey> g_music_keys;
 
-char *g_music_key_name[NUM_MUSIC_KEYS] =
-        {(char*)"A             ",
-         (char*)"A#/Bb",
-         (char*)"B",
-         (char*)"C",
-         (char*)"C#/Db",
-         (char*)"D",
-         (char*)"D#/Eb",
-         (char*)"E",
-         (char*)"F",
-         (char*)"F#/Gb",
-         (char*)"G",
-         (char*)"G#/Ab"
+const char *g_music_key_name[NUM_MUSIC_KEYS] =
+        {"A             ",
+         "A#/Bb",
+         "B",
+         "C",
+         "C#/Db",
+         "D",
+         "D#/Eb",
+         "E",
+         "F",
+         "F#/Gb",
+         "G",
+         "G#/Ab"
         };
 int g_music_key_root[NUM_MUSIC_KEYS] = {9, 10, 11, 0, 1, 2, 3, 4, 5, 6, 7, 8      };
 int g_music_key = 3; //C

--- a/general/music_key.h
+++ b/general/music_key.h
@@ -84,7 +84,7 @@ class MusicKey
 #define NUM_MUSIC_KEYS 12
 extern std::vector<MusicKey> g_music_keys;
 
-extern char * g_music_key_name[NUM_MUSIC_KEYS];
+extern const char * g_music_key_name[NUM_MUSIC_KEYS];
 extern int g_music_key_root[NUM_MUSIC_KEYS];
 extern int g_music_key;
 

--- a/general/mygl.hpp
+++ b/general/mygl.hpp
@@ -92,7 +92,7 @@ void mygl_resize2d( int p_width
                   , int p_height
                   )
 {
-    glViewport(0, 0, (GLint)p_width, (GLint)p_height);
+    glViewport(0, 0, static_cast<GLint>(p_width), static_cast<GLint>(p_height));
     glMatrixMode(GL_PROJECTION);
     glLoadIdentity();
     gluOrtho2D(0, p_width, p_height, 0);

--- a/general/myglfonts.cpp
+++ b/general/myglfonts.cpp
@@ -28,7 +28,7 @@ void MyGLFont::init(const QFont p_font)
 #endif // QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
         l_width_raw = l_width + 3;
         l_width_raw -= (l_width_raw % 4); //round length up to multiple of 4
-        l_data = (GLubyte*)malloc(l_width_raw * l_height * sizeof(GLubyte));
+        l_data = static_cast<GLubyte *>(malloc(l_width_raw * l_height * sizeof(GLubyte)));
         if(nullptr == l_data)
         {
             throw std::bad_alloc();

--- a/general/myio.cpp
+++ b/general/myio.cpp
@@ -55,8 +55,8 @@ long igetl(FILE *p_file)
             {
                 if((l_byte_4 = fgetc(p_file)) != EOF)
                 {
-                    return (((long)l_byte_4 << 24) | ((long)l_byte_3 << 16) |
-                            ((long)l_byte_2 << 8) | (long)l_byte_1
+                    return ((static_cast<long>(l_byte_4) << 24) | (static_cast<long>(l_byte_3) << 16) |
+                            (static_cast<long>(l_byte_2) << 8) | static_cast<long>(l_byte_1)
                            );
                 }
             }
@@ -106,10 +106,10 @@ long iputl( long p_long
     int l_byte_3;
     int l_byte_4;
 
-    l_byte_1 = (int)((p_long & 0xFF000000L) >> 24);
-    l_byte_2 = (int)((p_long & 0x00FF0000L) >> 16);
-    l_byte_3 = (int)((p_long & 0x0000FF00L) >> 8);
-    l_byte_4 = (int)p_long & 0x00FF;
+    l_byte_1 = static_cast<int>((p_long & 0xFF000000L) >> 24);
+    l_byte_2 = static_cast<int>((p_long & 0x00FF0000L) >> 16);
+    l_byte_3 = static_cast<int>((p_long & 0x0000FF00L) >> 8);
+    l_byte_4 = static_cast<int>(p_long & 0x00FF);
 
     if(fputc(l_byte_4, p_file) == l_byte_4)
     {
@@ -169,8 +169,8 @@ long mgetl(FILE * p_file)
             {
                 if((l_byte_4 = fgetc(p_file)) != EOF)
                 {
-                    return (((long)l_byte_1 << 24) | ((long)l_byte_2 << 16) |
-                            ((long)l_byte_3 << 8) | (long)l_byte_4
+                    return ((static_cast<long>(l_byte_1) << 24) | (static_cast<long>(l_byte_2) << 16) |
+                            (static_cast<long>(l_byte_3) << 8) | static_cast<long>(l_byte_4)
                            );
                 }
             }
@@ -220,10 +220,10 @@ long mputl( long p_long
     int l_byte_3;
     int l_byte_4;
 
-    l_byte_1 = (int)((p_long & 0xFF000000L) >> 24);
-    l_byte_2 = (int)((p_long & 0x00FF0000L) >> 16);
-    l_byte_3 = (int)((p_long & 0x0000FF00L) >> 8);
-    l_byte_4 = (int)p_long & 0x00FF;
+    l_byte_1 = static_cast<int>((p_long & 0xFF000000L) >> 24);
+    l_byte_2 = static_cast<int>((p_long & 0x00FF0000L) >> 16);
+    l_byte_3 = static_cast<int>((p_long & 0x0000FF00L) >> 8);
+    l_byte_4 = static_cast<int>(p_long & 0x00FF);
 
     if(fputc(l_byte_1, p_file) == l_byte_1)
     {

--- a/general/mystring.cpp
+++ b/general/mystring.cpp
@@ -50,7 +50,7 @@ char * copy_string(const char * p_s)
     {
         return NULL;
     }
-    char * l_t = (char *)malloc(strlen(p_s) + 1);
+    char * l_t = static_cast<char *>(malloc(strlen(p_s) + 1));
     if(nullptr == l_t)
     {
         throw std::bad_alloc();

--- a/general/mytransforms.cpp
+++ b/general/mytransforms.cpp
@@ -68,12 +68,12 @@ void MyTransforms::init( int p_n
     m_equal_loudness = p_equal_loudness;
     m_num_harmonics = p_num_harmonics;
 
-    m_data_temp = (float*)fftwf_malloc(sizeof(float) * m_n);
-    m_data_time = (float*)fftwf_malloc(sizeof(float) * m_n);
-    m_data_FFT  =  (float*)fftwf_malloc(sizeof(float) * m_n);
-    m_autocorr_time = (float*)fftwf_malloc(sizeof(float) * m_size);
-    m_autocorr_FFT  = (float*)fftwf_malloc(sizeof(float) * m_size);
-    m_hanning_coeff  = (float*)fftwf_malloc(sizeof(float) * m_n);
+    m_data_temp = static_cast<float*>(fftwf_malloc(sizeof(float) * m_n));
+    m_data_time = static_cast<float*>(fftwf_malloc(sizeof(float) * m_n));
+    m_data_FFT  =  static_cast<float*>(fftwf_malloc(sizeof(float) * m_n));
+    m_autocorr_time = static_cast<float*>(fftwf_malloc(sizeof(float) * m_size));
+    m_autocorr_FFT  = static_cast<float*>(fftwf_malloc(sizeof(float) * m_size));
+    m_hanning_coeff  = static_cast<float*>(fftwf_malloc(sizeof(float) * m_n));
 
     m_plan_autocorr_time_2_FFT = fftwf_plan_r2r_1d(m_size, m_autocorr_time, m_autocorr_FFT, FFTW_R2HC, l_my_FFT_mode);
     m_plan_autocorr_FFT_2_time = fftwf_plan_r2r_1d(m_size, m_autocorr_FFT, m_autocorr_time, FFTW_HC2R, l_my_FFT_mode);
@@ -81,12 +81,12 @@ void MyTransforms::init( int p_n
     m_plan_data_time_2_FFT = fftwf_plan_r2r_1d(m_n, m_data_time, m_data_FFT, FFTW_R2HC, l_my_FFT_mode);
     m_plan_data_FFT_2_time = fftwf_plan_r2r_1d(m_n, m_data_FFT, m_data_time, FFTW_HC2R, l_my_FFT_mode); //???
 
-    m_harmonics_amp_left = (float*)fftwf_malloc(m_num_harmonics * sizeof(float));
-    m_harmonics_phase_left = (float*)fftwf_malloc(m_num_harmonics * sizeof(float));
-    m_harmonics_amp_center = (float*)fftwf_malloc(m_num_harmonics * sizeof(float));
-    m_harmonics_phase_center = (float*)fftwf_malloc(m_num_harmonics * sizeof(float));
-    m_harmonics_amp_right = (float*)fftwf_malloc(m_num_harmonics * sizeof(float));
-    m_harmonics_phase_right = (float*)fftwf_malloc(m_num_harmonics * sizeof(float));
+    m_harmonics_amp_left = static_cast<float*>(fftwf_malloc(m_num_harmonics * sizeof(float)));
+    m_harmonics_phase_left = static_cast<float*>(fftwf_malloc(m_num_harmonics * sizeof(float)));
+    m_harmonics_amp_center = static_cast<float*>(fftwf_malloc(m_num_harmonics * sizeof(float)));
+    m_harmonics_phase_center = static_cast<float*>(fftwf_malloc(m_num_harmonics * sizeof(float)));
+    m_harmonics_amp_right = static_cast<float*>(fftwf_malloc(m_num_harmonics * sizeof(float)));
+    m_harmonics_phase_right = static_cast<float*>(fftwf_malloc(m_num_harmonics * sizeof(float)));
 
     m_freq_per_bin = m_rate / double(m_size);
     //init m_hanning_coeff. The hanning windowing function

--- a/general/useful.cpp
+++ b/general/useful.cpp
@@ -31,14 +31,14 @@ void ** malloc2d( const int p_row
                 , const int p_size
                 )
 {
-    void ** l_ptr = (void **)malloc(sizeof(void *) * p_row);
+    void ** l_ptr = static_cast<void**>(malloc(sizeof(void *) * p_row));
     if(nullptr == l_ptr)
     {
         throw std::bad_alloc();
     }
     for(int l_j = 0; l_j < p_row; l_j++)
     {
-        l_ptr[l_j] = (void *)malloc(p_size * p_col);
+        l_ptr[l_j] = static_cast<void *>(malloc(p_size * p_col));
         if(nullptr == l_ptr[l_j])
         {
             // Release previously allocated memory
@@ -71,7 +71,7 @@ void ** realloc2d( void ** p_ptr
             }
 
             {
-                void **l_new_ptr = (void **) realloc(p_ptr, sizeof(void *) * p_row);
+                void **l_new_ptr = static_cast<void **>(realloc(p_ptr, sizeof(void *) * p_row));
                 if (nullptr == l_new_ptr)
                 {
                     throw std::bad_alloc();
@@ -83,7 +83,7 @@ void ** realloc2d( void ** p_ptr
             {
                 for(l_j = 0; l_j < p_row; l_j++)
                 {
-                    void * l_new_ptr = (void *)realloc(p_ptr[l_j], p_size * p_col);
+                    void * l_new_ptr = static_cast<void *>(realloc(p_ptr[l_j], p_size * p_col));
                     if (nullptr == l_new_ptr)
                     {
                         throw std::bad_alloc();
@@ -96,7 +96,7 @@ void ** realloc2d( void ** p_ptr
         else if(p_row > p_old_row)
         {
             {
-                void **l_new_ptr = (void **) realloc(p_ptr, sizeof(void *) * p_row);
+                void **l_new_ptr = static_cast<void **>(realloc(p_ptr, sizeof(void *) * p_row));
                 if (nullptr == l_new_ptr)
                 {
                     throw std::bad_alloc();
@@ -107,7 +107,7 @@ void ** realloc2d( void ** p_ptr
             {
                 for(l_j = 0; l_j < p_old_row; l_j++)
                 {
-                    void * l_new_ptr = (void *)realloc(p_ptr[l_j], p_size * p_col);
+                    void * l_new_ptr = static_cast<void *>(realloc(p_ptr[l_j], p_size * p_col));
                     if (nullptr == l_new_ptr)
                     {
                         throw std::bad_alloc();
@@ -117,7 +117,7 @@ void ** realloc2d( void ** p_ptr
             }
             for(l_j = p_old_row; l_j < p_row; l_j++)
             {
-                p_ptr[l_j] = (void *)malloc(p_size * p_col);
+                p_ptr[l_j] = static_cast<void *>(malloc(p_size * p_col));
                 if(nullptr == p_ptr[l_j])
                 {
                     throw std::bad_alloc();
@@ -131,7 +131,7 @@ void ** realloc2d( void ** p_ptr
             {
                 for(l_j = 0; l_j < p_row; l_j++)
                 {
-                    void * l_new_ptr = (void *)realloc(p_ptr[l_j], p_size * p_col);
+                    void * l_new_ptr = static_cast<void *>(realloc(p_ptr[l_j], p_size * p_col));
                     if(nullptr == l_new_ptr)
                     {
                         throw std::bad_alloc();
@@ -323,7 +323,7 @@ int calcIndex( const double & p_frame_time
              , int p_size
              )
 {
-    int l_result = (int) myround((floor(p_frame_time / p_base_X) * p_base_X));
+    int l_result = static_cast<int>(myround((floor(p_frame_time / p_base_X) * p_base_X)));
     if (l_result < 0)
     {
         return 0;

--- a/include/array1d.hpp
+++ b/include/array1d.hpp
@@ -30,7 +30,7 @@ template<class T>
 Array1d<T>::Array1d(int p_length)
 : m_data_size(p_length)
 , m_allocated_size(nextPowerOf2(m_data_size))
-, m_data((T*)malloc(m_allocated_size * sizeof(T)))
+, m_data(static_cast<T *>(malloc(m_allocated_size * sizeof(T))))
 {
     myassert(m_data != NULL);
 }
@@ -42,7 +42,7 @@ Array1d<T>::Array1d( int p_length
                    )
 : m_data_size(p_length)
 , m_allocated_size(nextPowerOf2(m_data_size))
-, m_data((T*)malloc(m_allocated_size * sizeof(T)))
+, m_data(static_cast<T *>(malloc(m_allocated_size * sizeof(T))))
 {
     myassert(m_data != NULL);
     fill(p_val);
@@ -55,7 +55,7 @@ Array1d<T>::Array1d( const T * p_src
                    )
 : m_data_size(p_length)
 , m_allocated_size(nextPowerOf2(m_data_size))
-, m_data((T*)malloc(m_allocated_size * sizeof(T)))
+, m_data(static_cast<T *>(malloc(m_allocated_size * sizeof(T))))
 {
     myassert(m_data != NULL);
     for(T * l_p = m_data; l_p != end();)
@@ -69,7 +69,7 @@ template<class T>
 Array1d<T>::Array1d(Array1d<T> const & p_r)
 : m_data_size(p_r.size())
 , m_allocated_size(nextPowerOf2(m_data_size))
-, m_data((T*)malloc(m_allocated_size * sizeof(T)))
+, m_data(static_cast<T *>(malloc(m_allocated_size * sizeof(T))))
 {
     myassert(m_data != NULL);
     copy_raw(p_r.begin());
@@ -210,7 +210,7 @@ void Array1d<T>::resize_raw(int p_new_size)
             free(m_data);
         }
         m_allocated_size = nextPowerOf2(p_new_size);
-        m_data = (T*)malloc(m_allocated_size * sizeof(T)); //I think this is faster than realloc
+        m_data = static_cast<T *>(malloc(m_allocated_size * sizeof(T))); //I think this is faster than realloc
     }
     m_data_size = p_new_size;
 }
@@ -222,7 +222,7 @@ void Array1d<T>::resize(int p_new_size)
     if(p_new_size > m_allocated_size)
     {
         m_allocated_size = nextPowerOf2(p_new_size);
-        T * l_new_data_ptr = (T*)realloc(m_data, m_allocated_size * sizeof(T));
+        T * l_new_data_ptr = static_cast<T *>(realloc(m_data, m_allocated_size * sizeof(T)));
         if(nullptr == l_new_data_ptr)
         {
             throw std::bad_alloc();
@@ -241,7 +241,7 @@ void Array1d<T>::resize( int p_new_size
     if(p_new_size > m_allocated_size)
     {
         m_allocated_size = nextPowerOf2(p_new_size);
-        T * l_new_data_ptr = (T*)realloc(m_data, m_allocated_size * sizeof(T));
+        T * l_new_data_ptr = static_cast<T *>(realloc(m_data, m_allocated_size * sizeof(T)));
         if(nullptr == l_new_data_ptr)
         {
             throw std::bad_alloc();
@@ -276,7 +276,7 @@ void Array1d<T>::push_back(const T & p_val)
     if(++m_data_size > m_allocated_size)
     {
         m_allocated_size = nextPowerOf2(m_data_size);
-        T * l_new_data_ptr = (T*)realloc(m_data, m_allocated_size * sizeof(T));
+        T * l_new_data_ptr = static_cast<T *>(realloc(m_data, m_allocated_size * sizeof(T)));
         if(nullptr == l_new_data_ptr)
         {
             throw std::bad_alloc();

--- a/include/array2d.h
+++ b/include/array2d.h
@@ -139,7 +139,7 @@ Array2d<T>::Array2d( int p_width
     p_height = MAX(p_height, 0);
     m_width = p_width;
     m_height = p_height;
-    m_data = (T *)malloc(size() * sizeof(T));
+    m_data = static_cast<T *>(malloc(size() * sizeof(T)));
     myassert(m_data);
     //std::uninitialized_fill(begin(), end(), T());
 }
@@ -156,7 +156,7 @@ Array2d<T>::Array2d( int p_width
     p_height = MAX(p_height, 0);
     m_width = p_width;
     m_height = p_height;
-    m_data = (T *)malloc(size() * sizeof(T));
+    m_data = static_cast<T *>(malloc(size() * sizeof(T)));
     myassert(m_data);
     //for(T *p = data; p != end();)
     //*p++ = p_value;
@@ -272,7 +272,7 @@ void Array2d<T>::resize_raw( int p_width
     p_height = std::max(p_height, 0);
     m_width = p_width;
     m_height = p_height;
-    T * l_new_data_ptr = (T *)realloc(m_data, size() * sizeof(T));
+    T * l_new_data_ptr = static_cast<T *>(realloc(m_data, size() * sizeof(T)));
     if(nullptr == l_new_data_ptr)
     {
         throw std::bad_alloc();

--- a/rtAudio/audio_stream.cpp
+++ b/rtAudio/audio_stream.cpp
@@ -154,7 +154,7 @@ int AudioStream::callback( void * p_output_buffer
                          , void * p_user_data
                          )
 {
-    AudioStream * l_self = (AudioStream *) p_user_data;
+    AudioStream * l_self = static_cast<AudioStream *>(p_user_data);
     
     // Call the callback instance method on "this" object.
     return l_self->callback(p_output_buffer, p_input_buffer, p_n_buffer_frames, p_stream_time, p_status);
@@ -173,8 +173,8 @@ int AudioStream::callback( void * p_output_buffer
 #endif // DEBUG_PRINTF
 
     // unsigned int i, j;
-    float * l_out_buffer = (float *) p_output_buffer;
-    float * l_in_buffer = (float *) p_input_buffer;
+    float * l_out_buffer = static_cast<float *>(p_output_buffer);
+    float * l_in_buffer = static_cast<float *>(p_input_buffer);
 
     if (p_status == RTAUDIO_INPUT_OVERFLOW)
     {

--- a/sound/channel.cpp
+++ b/sound/channel.cpp
@@ -458,7 +458,7 @@ void Channel::recalcScoreThresholds()
 //------------------------------------------------------------------------------
 bool Channel::isVisibleNote(int p_note_index) const
 {
-    myassert(p_note_index < (int)m_note_data.size());
+    myassert(p_note_index < static_cast<int>(m_note_data.size()));
     if(p_note_index == NO_NOTE)
     {
         return false;
@@ -494,9 +494,9 @@ bool Channel::isChangingChunk(AnalysisData * p_data) const
 //------------------------------------------------------------------------------
 void Channel::backTrackNoteChange(int p_chunk)
 {
-    int l_first = MAX(p_chunk - (int)ceil(g_long_time / timePerChunk()), getLastNote()->startChunk());
+    int l_first = MAX(p_chunk - static_cast<int>(ceil(g_long_time / timePerChunk())), getLastNote()->startChunk());
 #ifdef DEBUG_PRINTF
-    printf("ceil = %d, %d\n", (int)ceil(g_long_time / timePerChunk()), p_chunk-l_first);
+    printf("ceil = %d, %d\n", static_cast<int>(ceil(g_long_time / timePerChunk())), p_chunk-l_first);
 #endif // DEBUG_PRINTF
     int l_last = p_chunk; //currentNote->endChunk();
     if(l_first >= l_last)
@@ -586,7 +586,7 @@ bool Channel::isNoteChanging(int p_chunk)
         return true;
     }
 
-    int l_first_short_chunk = MAX(p_chunk - (int)ceil(g_short_time / timePerChunk()), getLastNote()->startChunk());
+    int l_first_short_chunk = MAX(p_chunk - static_cast<int>(ceil(g_short_time / timePerChunk())), getLastNote()->startChunk());
     AnalysisData * l_first_short_data = dataAtChunk(l_first_short_chunk);
     double l_spread_2 = fabs(l_analysis_data->getShortTermMean() - l_first_short_data->getLongTermMean()) -
                              (l_analysis_data->getShortTermDeviation() + l_first_short_data->getLongTermDeviation()
@@ -594,7 +594,7 @@ bool Channel::isNoteChanging(int p_chunk)
     l_analysis_data->setSpread(l_spread);
     l_analysis_data->setSpread2(l_spread_2);
 
-    if(l_num_chunks >= (int)(ceil(g_long_time / timePerChunk()) / 2.0) && l_spread_2 > 0.0)
+    if(l_num_chunks >= static_cast<int>(ceil(g_long_time / timePerChunk()) / 2.0) && l_spread_2 > 0.0)
     {
         l_analysis_data->setReason(4);
         return true;
@@ -615,7 +615,7 @@ bool Channel::isNoteChanging(int p_chunk)
 //------------------------------------------------------------------------------
 bool Channel::isLabelNote(int p_note_index) const
 {
-    myassert(p_note_index < (int)m_note_data.size());
+    myassert(p_note_index < static_cast<int>(m_note_data.size()));
     if(p_note_index >= 0 && m_note_data[p_note_index].isValid())
     {
         return true;
@@ -802,7 +802,7 @@ const NoteData * Channel::getCurrentNote() const
     if(l_analysis_data)
     {
         int l_note_index = l_analysis_data->getNoteIndex();
-        if(l_note_index >= 0 && l_note_index < (int)m_note_data.size())
+        if(l_note_index >= 0 && l_note_index < static_cast<int>(m_note_data.size()))
         {
             return &m_note_data[l_note_index];
         }
@@ -813,7 +813,7 @@ const NoteData * Channel::getCurrentNote() const
 //------------------------------------------------------------------------------
 const NoteData * Channel::getNote(int p_note_index) const
 {
-    if(p_note_index >= 0 && p_note_index < (int)m_note_data.size())
+    if(p_note_index >= 0 && p_note_index < static_cast<int>(m_note_data.size()))
     {
         return &m_note_data[p_note_index];
     }
@@ -853,8 +853,8 @@ void Channel::chooseCorrelationIndex1(int p_chunk)
     double l_freq = rate() / l_analysis_data.getPeriod();
     l_analysis_data.setFundamentalFreq(float(l_freq));
     l_analysis_data.setPitch(bound(freq2pitch(l_freq), 0.0, g_data->topPitch()));
-    l_analysis_data.setPitchSum((double)l_analysis_data.getPitch());
-    l_analysis_data.setPitch2Sum(sq((double)l_analysis_data.getPitch()));
+    l_analysis_data.setPitchSum(static_cast<double>(l_analysis_data.getPitch()));
+    l_analysis_data.setPitch2Sum(sq(static_cast<double>(l_analysis_data.getPitch())));
 }
 
 //------------------------------------------------------------------------------
@@ -904,13 +904,13 @@ bool Channel::chooseCorrelationIndex( int p_chunk
     l_analysis_data.setPitch(bound(freq2pitch(l_freq), 0.0, g_data->topPitch()));
     if(p_chunk > 0 && !isFirstChunkInNote(p_chunk))
     {
-        l_analysis_data.setPitchSum(dataAtChunk(p_chunk - 1)->getPitchSum() + (double)l_analysis_data.getPitch());
-        l_analysis_data.setPitch2Sum(dataAtChunk(p_chunk - 1)->getPitch2Sum() + sq((double)l_analysis_data.getPitch()));
+        l_analysis_data.setPitchSum(dataAtChunk(p_chunk - 1)->getPitchSum() + static_cast<double>(l_analysis_data.getPitch()));
+        l_analysis_data.setPitch2Sum(dataAtChunk(p_chunk - 1)->getPitch2Sum() + sq(static_cast<double>(l_analysis_data.getPitch())));
     }
     else
     {
-        l_analysis_data.setPitchSum((double)l_analysis_data.getPitch());
-        l_analysis_data.setPitch2Sum(sq((double)l_analysis_data.getPitch()));
+        l_analysis_data.setPitchSum(static_cast<double>(l_analysis_data.getPitch()));
+        l_analysis_data.setPitch2Sum(sq(static_cast<double>(l_analysis_data.getPitch())));
     }
     return l_is_different_index;
 }
@@ -928,7 +928,7 @@ void Channel::calcDeviation(int p_chunk)
     }
 
     //Do long term calculation
-    int l_first_chunk = MAX(l_last_chunk - (int)ceil(g_long_time / timePerChunk()), m_note_data[l_current_note_index].startChunk());
+    int l_first_chunk = MAX(l_last_chunk - static_cast<int>(ceil(g_long_time / timePerChunk())), m_note_data[l_current_note_index].startChunk());
     AnalysisData * l_first_chunk_data = dataAtChunk(l_first_chunk);
     int l_num_chunks = (l_last_chunk - l_first_chunk);
     double l_mean_sum;
@@ -953,7 +953,7 @@ void Channel::calcDeviation(int p_chunk)
     }
 
     //Do short term calculation
-    l_first_chunk = MAX(l_last_chunk - (int)ceil(g_short_time / timePerChunk()), m_note_data[l_current_note_index].startChunk());
+    l_first_chunk = MAX(l_last_chunk - static_cast<int>(ceil(g_short_time / timePerChunk())), m_note_data[l_current_note_index].startChunk());
     l_first_chunk_data = dataAtChunk(l_first_chunk);
     l_num_chunks = (l_last_chunk - l_first_chunk);
     if(l_num_chunks > 0)
@@ -1165,7 +1165,7 @@ float Channel::calcDetailedPitch( float * p_input
 #endif // DEBUG_PRINTF
     for(l_j = 0; l_j < l_num; l_j++)
     {
-        m_detailed_pitch_data_smoothed[l_j] = bound(m_detailed_pitch_data_smoothed[l_j], 0.0f, (float)g_data->topPitch());
+        m_detailed_pitch_data_smoothed[l_j] = bound(m_detailed_pitch_data_smoothed[l_j], 0.0f, static_cast<float>(g_data->topPitch()));
     }
 
     m_pitch_small_smoothing_filter->filter(l_unsmoothed.begin(), m_detailed_pitch_data.begin(), l_num);
@@ -1174,7 +1174,7 @@ float Channel::calcDetailedPitch( float * p_input
 #endif // DEBUG_PRINTF
     for(l_j = 0; l_j < l_num; l_j++)
     {
-        m_detailed_pitch_data[l_j] = bound(m_detailed_pitch_data[l_j], 0.0f, (float)g_data->topPitch());
+        m_detailed_pitch_data[l_j] = bound(m_detailed_pitch_data[l_j], 0.0f, static_cast<float>(g_data->topPitch()));
     }
 #ifdef DEBUG_PRINTF
     printf("end calcDetailedPitch\n"); fflush(stdout);

--- a/sound/notedata.cpp
+++ b/sound/notedata.cpp
@@ -111,7 +111,7 @@ void NoteData::addVibratoData(int p_chunk)
         int l_loop_limit = ((p_chunk + 1) * m_channel->framesPerChunk()) - m_loop_step;
         for(int l_current_time = m_loop_start; l_current_time < l_loop_limit; l_current_time += m_loop_step)
         {
-            myassert(l_current_time + m_loop_step < (int)m_channel->get_pitch_lookup_smoothed().size());
+            myassert(l_current_time + m_loop_step < static_cast<int>(m_channel->get_pitch_lookup_smoothed().size()));
             myassert(l_current_time - m_loop_step >= 0);
             float l_prev_pitch = m_channel->get_pitch_lookup_smoothed().at(l_current_time - m_loop_step);
             float l_current_pitch = m_channel->get_pitch_lookup_smoothed().at(l_current_time);

--- a/sound/sound_stream.cpp
+++ b/sound/sound_stream.cpp
@@ -41,7 +41,7 @@ int SoundStream::writeFloats( float ** p_channel_data
             unsigned char * l_pos1 = l_temp + l_c;
             for(l_pos = p_channel_data[l_c % p_ch]; l_pos < l_end; l_pos++, l_pos1 += m_channels)
             {
-                *l_pos1 = (unsigned char)((*l_pos * g_v8) + g_v8);
+                *l_pos1 = static_cast<unsigned char>((*l_pos * g_v8) + g_v8);
             }
         }
         l_written = write_bytes(l_temp, p_length * m_channels);
@@ -59,7 +59,7 @@ int SoundStream::writeFloats( float ** p_channel_data
             short * l_pos1 = l_temp + l_c;
             for(l_pos = p_channel_data[l_c % p_ch]; l_pos < l_end; l_pos++, l_pos1 += m_channels)
             {
-                *l_pos1 = (short)(*l_pos * g_v16);
+                *l_pos1 = static_cast<short>(*l_pos * g_v16);
 #ifdef IS_BIG_ENDIAN
                 *l_pos1 = ((*l_pos1 & 0xFF00) >> 8) | ((*l_pos1 & 0x00FF) << 8);
 #endif

--- a/widgets/drawwidget.cpp
+++ b/widgets/drawwidget.cpp
@@ -223,7 +223,7 @@ void DrawWidget::drawChannel(QPaintDevice & p_paint_device,
       float l_err = 0.0, l_pitch = 0.0, l_prev_pitch = 0.0, vol;
 
       // Integer version of frame time
-      int l_int_chunk = (int) floor(l_frame_time);
+      int l_int_chunk = static_cast<int>(floor(l_frame_time));
       if(l_int_chunk < 0)
 	{
 	  l_int_chunk = 0;
@@ -241,7 +241,7 @@ void DrawWidget::drawChannel(QPaintDevice & p_paint_device,
       int l_half_square_size = l_square_size / 2;
       int l_pen_X = 0, l_pen_Y = 0;
 
-      for (double l_n = l_start; l_n < l_stop && l_int_chunk < (int)p_channel->totalChunks(); l_n += l_step_size, l_int_chunk++)
+      for (double l_n = l_start; l_n < l_stop && l_int_chunk < static_cast<int>(p_channel->totalChunks()); l_n += l_step_size, l_int_chunk++)
 	{
 	  myassert(l_int_chunk >= 0);
 	  AnalysisData * l_data = p_channel->dataAtChunk(l_int_chunk);
@@ -466,7 +466,7 @@ void DrawWidget::drawChannelFilled(Channel * p_channel,
       float l_err = 0.0;
       float l_pitch = 0.0;
       // Integer version of frame time
-      int l_int_chunk = (int) floor(l_frame_time);
+      int l_int_chunk = static_cast<int>(floor(l_frame_time));
       if(l_int_chunk < 0)
 	{
 	  l_int_chunk = 0;
@@ -479,7 +479,7 @@ void DrawWidget::drawChannelFilled(Channel * p_channel,
       double l_stop = width() + (2 * l_step_size);
       l_bottom_points.setPoint(l_point_index++, toInt(l_start), height());
       l_last_N = l_first_N = toInt(l_start);
-      for (double l_n = l_start; l_n < l_stop && l_int_chunk < (int)p_channel->totalChunks(); l_n += l_step_size, l_int_chunk++)
+      for (double l_n = l_start; l_n < l_stop && l_int_chunk < static_cast<int>(p_channel->totalChunks()); l_n += l_step_size, l_int_chunk++)
 	{
 	  myassert(l_int_chunk >= 0);
 	  AnalysisData * l_data = p_channel->dataAtChunk(l_int_chunk);
@@ -677,7 +677,7 @@ void DrawWidget::setChannelVerticalView(Channel * p_channel,
       // More pixels than samples
     float l_pitch = 0.0;
     // Integer version of frame time
-    int l_int_chunk = (int) floor(l_frame_time);
+    int l_int_chunk = static_cast<int>(floor(l_frame_time));
     if(l_int_chunk < 0)
       {
 	l_int_chunk = 0;
@@ -688,7 +688,7 @@ void DrawWidget::setChannelVerticalView(Channel * p_channel,
     
     double l_start = (double(l_int_chunk) - l_frame_time) * l_step_size;
     double l_stop = width() + (2 * l_step_size);
-    for (double l_current_value = l_start; l_current_value < l_stop && l_int_chunk < (int)p_channel->totalChunks(); l_current_value += l_step_size, l_int_chunk++)
+    for (double l_current_value = l_start; l_current_value < l_stop && l_int_chunk < static_cast<int>(p_channel->totalChunks()); l_current_value += l_step_size, l_int_chunk++)
       {
 	myassert(l_int_chunk >= 0);
 	AnalysisData * l_data = p_channel->dataAtChunk(l_int_chunk);
@@ -731,12 +731,12 @@ bool DrawWidget::calcZoomElement(Channel * p_channel,
 {
   int l_start_chunk = toInt(double(p_base_element) * p_base_X);
   int l_finish_chunk = toInt(double(p_base_element + 1) * p_base_X) + 1;
-  if(l_finish_chunk >= (int)p_channel->totalChunks())
+  if(l_finish_chunk >= static_cast<int>(p_channel->totalChunks()))
     {
       //dont go off the end
       l_finish_chunk--;
     }
-  if(l_finish_chunk >= (int)p_channel->totalChunks())
+  if(l_finish_chunk >= static_cast<int>(p_channel->totalChunks()))
     {
       //that data doesn't exist yet
       return false;

--- a/widgets/freq/amplitudewidget.cpp
+++ b/widgets/freq/amplitudewidget.cpp
@@ -354,7 +354,7 @@ void AmplitudeWidget::drawChannelAmplitudeGL(Channel *p_channel)
         //l_base_X <= 1
         float l_val = 0.0;
         // Integer version of frame time
-        int l_int_chunk = (int) floor(l_left_frame_time);
+        int l_int_chunk = static_cast<int>(floor(l_left_frame_time));
         // So we skip some pixels
         double l_step_size = 1.0 / l_base_X;
         float l_x = 0.0f, l_y;
@@ -455,7 +455,7 @@ void AmplitudeWidget::drawChannelAmplitudeFilledGL(Channel *p_channel)
         //l_base_X <= 1
         float l_val = 0.0;
         // Integer version of frame time
-        int l_int_chunk = (int) floor(l_left_frame_time);
+        int l_int_chunk = static_cast<int>(floor(l_left_frame_time));
         // So we skip some pixels
         double l_step_size = 1.0 / l_base_X;
         float l_x = 0.0f, l_y;

--- a/widgets/freq/freqwidgetGL.cpp
+++ b/widgets/freq/freqwidgetGL.cpp
@@ -205,12 +205,12 @@ void FreqWidgetGL::drawReferenceLinesGL( const double & /* p_left_time*/
     MusicScale &l_music_scale = g_music_scales[g_data->musicKeyType()];
 
     int l_key_root = cycle(g_music_key_root[g_data->musicKey()] + l_music_scale.semitoneOffset(), 12);
-    int l_view_bottom_note = (int)p_view_bottom - l_key_root;
+    int l_view_bottom_note = static_cast<int>(p_view_bottom) - l_key_root;
     int l_remainder = cycle(l_view_bottom_note, 12);
     int l_low_root = l_view_bottom_note - l_remainder + l_key_root;
     int l_root_octave = l_low_root / 12;
     int l_root_offset = cycle(l_low_root, 12);
-    int l_num_octaves = int(ceil(p_zoom_Y * (double)height() / 12.0)) + 1;
+    int l_num_octaves = int(ceil(p_zoom_Y * static_cast<double>(height()) / 12.0)) + 1;
     int l_top_octave = l_root_octave + l_num_octaves;
     double l_line_Y;
     double l_cur_root;
@@ -383,7 +383,7 @@ void FreqWidgetGL::paintGL()
         QColor l_line_color = l_foreground;
         l_line_color.setAlpha(50);
         Channel *l_channel = g_data->getActiveChannel();
-        double l_half_window_time = (double)l_channel->size() / (double)(l_channel->rate() * 2);
+        double l_half_window_time = static_cast<double>(l_channel->size()) / static_cast<double>(l_channel->rate() * 2);
         int l_pixel_left = l_view.screenPixelX(l_view.currentTime() - l_half_window_time);
         int l_pixel_right = l_view.screenPixelX(l_view.currentTime() + l_half_window_time);
         qglColor(l_line_color);
@@ -781,7 +781,7 @@ void FreqWidgetGL::drawChannelGL( Channel *p_channel
         float l_vol;
 
         // Integer version of frame time
-        int l_int_chunk = (int) floor(l_frame_time);
+        int l_int_chunk = static_cast<int>(floor(l_frame_time));
         if(l_int_chunk < 0)
         {
             l_int_chunk = 0;
@@ -800,7 +800,7 @@ void FreqWidgetGL::drawChannelGL( Channel *p_channel
         int l_pen_X = 0;
         int l_pen_Y = 0;
 
-        for(double l_double_index = l_start; l_double_index < l_stop && l_int_chunk < (int)p_channel->totalChunks(); l_double_index += l_step_size, l_int_chunk++)
+        for(double l_double_index = l_start; l_double_index < l_stop && l_int_chunk < static_cast<int>(p_channel->totalChunks()); l_double_index += l_step_size, l_int_chunk++)
         {
             myassert(l_int_chunk >= 0);
             AnalysisData * l_data = p_channel->dataAtChunk(l_int_chunk);
@@ -832,7 +832,7 @@ void FreqWidgetGL::drawChannelGL( Channel *p_channel
                 if(fabs(l_prev_pitch - l_pitch) < 1.0 && l_double_index != l_start)
                 {
                     //if closer than one semi-tone from previous then draw a line between them
-                    mygl_line((float)l_pen_X, (float)l_pen_Y, (float)l_x, (float)l_y);
+                    mygl_line(static_cast<float>(l_pen_X), static_cast<float>(l_pen_Y), static_cast<float>(l_x), static_cast<float>(l_y));
                     l_pen_X = l_x;
                     l_pen_Y = l_y;
                 }
@@ -1026,7 +1026,7 @@ void FreqWidgetGL::drawChannelFilledGL( Channel *p_channel
         float l_err = 0.0;
         float l_pitch = 0.0;
         // Integer version of frame time
-        int l_int_chunk = (int) floor(l_frame_time);
+        int l_int_chunk = static_cast<int>(floor(l_frame_time));
         if(l_int_chunk < 0)
         {
             l_int_chunk = 0;
@@ -1042,7 +1042,7 @@ void FreqWidgetGL::drawChannelFilledGL( Channel *p_channel
         double l_start = (double(l_int_chunk) - l_frame_time) * l_step_size;
         double l_stop = width() + (2 * l_step_size);
         l_last_N = l_first_N = toInt(l_start);
-        for(double l_double_index = l_start; l_double_index < l_stop && l_int_chunk < (int)p_channel->totalChunks(); l_double_index += l_step_size, l_int_chunk++)
+        for(double l_double_index = l_start; l_double_index < l_stop && l_int_chunk < static_cast<int>(p_channel->totalChunks()); l_double_index += l_step_size, l_int_chunk++)
         {
             myassert(l_int_chunk >= 0);
             AnalysisData *l_data = p_channel->dataAtChunk(l_int_chunk);
@@ -1140,12 +1140,12 @@ bool FreqWidgetGL::calcZoomElement( Channel * p_channel
 {
     int l_start_chunk = toInt(double(p_base_element) * p_base_X);
     int l_finish_chunk = toInt(double(p_base_element + 1) * p_base_X) + 1;
-    if(l_finish_chunk >= (int)p_channel->totalChunks())
+    if(l_finish_chunk >= static_cast<int>(p_channel->totalChunks()))
     {
         //dont go off the end
         l_finish_chunk--;
     }
-    if(l_finish_chunk >= (int)p_channel->totalChunks())
+    if(l_finish_chunk >= static_cast<int>(p_channel->totalChunks()))
     {
         //that data doesn't exist yet
         return false;
@@ -1293,7 +1293,7 @@ void FreqWidgetGL::setChannelVerticalView( Channel * p_channel
         // More pixels than samples
         float l_pitch = 0.0;
         // Integer version of frame time
-        int l_int_chunk = (int) floor(l_frame_time);
+        int l_int_chunk = static_cast<int>(floor(l_frame_time));
         if(l_int_chunk < 0)
         {
             l_int_chunk = 0;
@@ -1304,7 +1304,7 @@ void FreqWidgetGL::setChannelVerticalView( Channel * p_channel
 
         double l_start = (double(l_int_chunk) - l_frame_time) * l_step_size;
         double l_stop = width() + (2 * l_step_size);
-        for(double l_double_index = l_start; l_double_index < l_stop && l_int_chunk < (int)p_channel->totalChunks(); l_double_index += l_step_size, l_int_chunk++)
+        for(double l_double_index = l_start; l_double_index < l_stop && l_int_chunk < static_cast<int>(p_channel->totalChunks()); l_double_index += l_step_size, l_int_chunk++)
         {
             myassert(l_int_chunk >= 0);
             AnalysisData *l_data = p_channel->dataAtChunk(l_int_chunk);

--- a/widgets/hbubble/hbubblewidget.cpp
+++ b/widgets/hbubble/hbubblewidget.cpp
@@ -49,7 +49,7 @@ void HBubbleWidget::setNumHarmonics(double num)
     if (m_num_harmonics != toInt(num))
     {
         m_num_harmonics = toInt(num);
-        emit numHarmonicsChanged((double)num);
+        emit numHarmonicsChanged(static_cast<double>(num));
     }
 }
 
@@ -60,7 +60,7 @@ void HBubbleWidget::setHistoryChunks(double num)
     if (m_history_chunks != toInt(num))
     {
         m_history_chunks = toInt(num);
-        emit historyChunksChanged((double)num);
+        emit historyChunksChanged(static_cast<double>(num));
     }
 }
 
@@ -93,7 +93,7 @@ void HBubbleWidget::paintEvent( QPaintEvent * )
                 {
                     for(l_i = 0; l_i < m_num_harmonics; l_i++)
                     {
-                        int l_radius = toInt((l_data->getHarmonicAmpNoCutOffAt(l_i) + 160.0) / 160.0 * (float)height() / m_num_harmonics / 2);
+                        int l_radius = toInt((l_data->getHarmonicAmpNoCutOffAt(l_i) + 160.0) / 160.0 * static_cast<float>(height()) / m_num_harmonics / 2);
                         if(l_radius > 0)
                         {
                             float l_flat_sharp = (l_data->getHarmonicFreqAt(l_i) / l_data->getFundamentalFreq() - (l_i + 1)) * 10;
@@ -106,9 +106,9 @@ void HBubbleWidget::paintEvent( QPaintEvent * )
                             {
                                 l_color = colorBetween(qRgb(255,255,255), qRgb(0,0,255),-l_flat_sharp);
                             }
-                            get_painter().setBrush(colorBetween(g_data->backgroundColor(),l_color,((l_j == (m_history_chunks - 1)) ? 1.0 : (float)l_j / m_history_chunks * 0.5)));
-                            get_painter().drawEllipse( toInt(width() / 8 * 3 + l_j * (float)width() / 8 / m_history_chunks - l_radius)
-                                                     , toInt(height() - (float) ((l_i + 1) * height()) / (m_num_harmonics + 2) - l_radius)
+                            get_painter().setBrush(colorBetween(g_data->backgroundColor(),l_color,((l_j == (m_history_chunks - 1)) ? 1.0 : static_cast<float>(l_j) / m_history_chunks * 0.5)));
+                            get_painter().drawEllipse( toInt(width() / 8 * 3 + l_j * static_cast<float>(width()) / 8 / m_history_chunks - l_radius)
+                                                     , toInt(height() - static_cast<float>((l_i + 1) * height()) / (m_num_harmonics + 2) - l_radius)
                                                      , l_radius * 2
                                                      , l_radius * 2
                                                      );

--- a/widgets/hcircle/hcirclewidget.cpp
+++ b/widgets/hcircle/hcirclewidget.cpp
@@ -93,7 +93,7 @@ void HCircleWidget::paintEvent( QPaintEvent * )
     if(m_threshold > m_lowest_value)
     {
         get_painter().setPen(QPen(colorBetween(g_data->backgroundColor(), qRgb(128,128,128), 0.3), 2));
-        int l_radius = toInt((double)height() * m_zoom * (m_threshold - m_lowest_value));
+        int l_radius = toInt(static_cast<double>(height()) * m_zoom * (m_threshold - m_lowest_value));
         get_painter().drawEllipse(width() / 2 - l_radius, height() / 2 - l_radius, 2 * l_radius, 2 * l_radius);
         get_painter().drawText(width() / 2 - l_radius + 5, height() / 2, "Threshold");
     }
@@ -106,7 +106,7 @@ void HCircleWidget::paintEvent( QPaintEvent * )
     {
         if (l_scale > m_lowest_value)
         {
-            int l_radius = toInt((double)height() * m_zoom * (l_scale - m_lowest_value));
+            int l_radius = toInt(static_cast<double>(height()) * m_zoom * (l_scale - m_lowest_value));
             get_painter().drawEllipse(width() / 2 - l_radius,height() / 2 - l_radius, 2 * l_radius, 2 * l_radius);
 	        std::stringstream l_stream;
 	        l_stream << std::fixed << std::setprecision(1) << l_scale;
@@ -132,7 +132,7 @@ void HCircleWidget::paintEvent( QPaintEvent * )
             int l_dot_size = 6;
             int l_half_dot_size = l_dot_size / 2;
             get_painter().setPen(QPen(Qt::black, 2));
-            int l_m = MIN(l_data->getHarmonicAmpNoCutOffSize(), (unsigned) l_num_harmonics);
+            int l_m = MIN(l_data->getHarmonicAmpNoCutOffSize(), static_cast<unsigned>(l_num_harmonics));
             assert(l_data->getHarmonicAmpNoCutOffSize() == l_data->getHarmonicFreqSize());
             for(l_i = 0; l_i < l_m; l_i++)
             {

--- a/widgets/hstack/hstackwidget.cpp
+++ b/widgets/hstack/hstackwidget.cpp
@@ -46,7 +46,7 @@ void HStackWidget::setWindowSize(double p_window_size)
     if(m_window_size != p_window_size)
     {
         m_window_size = toInt(p_window_size);
-        emit windowSizeChanged((float)m_window_size);
+        emit windowSizeChanged(static_cast<float>(m_window_size));
     }
 }
 
@@ -106,7 +106,7 @@ void HStackWidget::paintEvent(QPaintEvent *)
         int l_num_harmonics = 16;
         
         float l_scale_Y = height() / m_view_height;
-        float l_scale_X = (float)width() / (float)m_window_size;
+        float l_scale_X = static_cast<float>(width()) / static_cast<float>(m_window_size);
         int l_not_on_graph = height() + 10;
 
         QPolygon l_points[l_num_harmonics];
@@ -146,28 +146,28 @@ void HStackWidget::paintEvent(QPaintEvent *)
             l_data = l_active_channel->dataAtChunk(l_start_chunk + l_i);
             if (l_data != 0) 
             { 
-                int l_m = MIN(l_data->getHarmonicAmpNoCutOffSize(), (unsigned) l_num_harmonics);
+                int l_m = MIN(l_data->getHarmonicAmpNoCutOffSize(), static_cast<unsigned>(l_num_harmonics));
                 for(l_j = 0; l_j < l_m;l_j++) 
                 { 
                     if (!isinf(l_data->getHarmonicAmpNoCutOffAt(l_j))) 
                     { 
-                        l_points[l_j].setPoint(l_i + 2, toInt(l_scale_X * (float)l_i), -toInt((-m_top + l_data->getHarmonicAmpNoCutOffAt(l_j)) * l_scale_Y)); 
+                        l_points[l_j].setPoint(l_i + 2, toInt(l_scale_X * static_cast<float>(l_i)), -toInt((-m_top + l_data->getHarmonicAmpNoCutOffAt(l_j)) * l_scale_Y));
                     } 
                     else 
                     { 
-                        l_points[l_j].setPoint(l_i + 2, toInt(l_scale_X * (float)l_i), l_not_on_graph); 
+                        l_points[l_j].setPoint(l_i + 2, toInt(l_scale_X * static_cast<float>(l_i)), l_not_on_graph);
                     } 
                 }
                 for (l_j = l_m; l_j < l_num_harmonics; l_j++) 
                 { 
-                    l_points[l_j].setPoint(l_i + 2, toInt(l_scale_X * (float)l_i), l_not_on_graph); 
+                    l_points[l_j].setPoint(l_i + 2, toInt(l_scale_X * static_cast<float>(l_i)), l_not_on_graph);
                 } 
             } 
             else 
             { 
                 for(l_j = 0; l_j < l_num_harmonics;l_j++) 
                 { 
-                    l_points[l_j].setPoint(l_i + 2,toInt(l_scale_X * (float)l_i),l_not_on_graph); 
+                    l_points[l_j].setPoint(l_i + 2,toInt(l_scale_X * static_cast<float>(l_i)),l_not_on_graph);
                 } 
             } 
         }

--- a/widgets/htrack/htrackwidget.cpp
+++ b/widgets/htrack/htrackwidget.cpp
@@ -78,7 +78,7 @@ void HTrackWidget::resizeGL( int p_w
                            )
 {
     // setup viewport, projection etc.:
-    glViewport( 0, 0, (GLint)p_w, (GLint)p_h );
+    glViewport( 0, 0, static_cast<GLint>(p_w), static_cast<GLint>(p_h) );
 }
 
 //------------------------------------------------------------------------------

--- a/widgets/mainwindow/mainwindow.cpp
+++ b/widgets/mainwindow/mainwindow.cpp
@@ -398,7 +398,7 @@ MainWindow::MainWindow()
 
     // the parameters defining how the slider behave inside the scale is now defined in class qwt_abstract_slider
     double l_range_wdith = ( g_data->leftTime() < g_data->rightTime() ? g_data->rightTime() - g_data->leftTime() : g_data->leftTime() - g_data->rightTime());
-    unsigned int l_nb_steps = ((unsigned int)(l_range_wdith * 10000.0));
+    unsigned int l_nb_steps = (static_cast<unsigned int>(l_range_wdith * 10000.0));
     m_time_slider->setTotalSteps(l_nb_steps);
     m_time_slider->setPageSteps(1000);
 
@@ -734,8 +734,8 @@ void MainWindow::openFile(const char *p_file_name)
 #endif // TIME_PREPROCESS
     l_new_sound_file->preProcess();
 #ifdef TIME_PREPROCESS
-    double l_ms_per_chunk = (double)l_timer.elapsed() / l_new_sound_file->totalChunks();
-    double l_frames_per_sec = 1000 * l_new_sound_file->totalChunks() * l_new_sound_file->framesPerChunk() / (double)l_timer.elapsed();
+    double l_ms_per_chunk = static_cast<double>(l_timer.elapsed()) / l_new_sound_file->totalChunks();
+    double l_frames_per_sec = 1000 * l_new_sound_file->totalChunks() * l_new_sound_file->framesPerChunk() / static_cast<double>(l_timer.elapsed());
     std::cout << "Pre-processing took " << l_timer.elapsed() << " ms for " << l_new_sound_file->totalChunks() << " chunks (" <<
         l_ms_per_chunk << " ms per chunk, " << l_frames_per_sec << " frames/sec)" << std::endl;
 #endif // TIME_PREPROCESS
@@ -1109,7 +1109,7 @@ void MainWindow::setTimeRange( double p_min
         m_time_slider->setScale(p_min, p_max);
         // and steps and pages are managed by qwt_abstract_slider class
         double l_range_wdith = ( p_min < p_max ? p_max - p_min : p_min - p_max);
-        unsigned int l_nb_steps = ((unsigned int)(l_range_wdith * 10000.0));
+        unsigned int l_nb_steps = (static_cast<unsigned int>(l_range_wdith * 10000.0));
         m_time_slider->setTotalSteps(l_nb_steps > m_time_slider->totalSteps() ? l_nb_steps : m_time_slider->totalSteps());
         m_time_slider->setPageSteps(1000);
 #else // QWT_VERSION >= 0x060000
@@ -1307,7 +1307,7 @@ bool MainWindow::loadViewGeometry()
             l_size = g_data->getSettingsValue((l_base + "/size").toStdString(), QSize(100, 100));
             QWidget * l_widget = openView(l_j);
             //get the subwindow frame
-            QWidget * l_parent_widget = (QWidget*)(l_widget->parent());
+            QWidget * l_parent_widget = static_cast<QWidget*>(l_widget->parent());
             if(l_parent_widget)
             {
                 l_parent_widget->resize(l_size);

--- a/widgets/openfiles/openfiles.cpp
+++ b/widgets/openfiles/openfiles.cpp
@@ -104,7 +104,7 @@ void OpenFiles::listViewChanged()
     {
         QCheckBox * l_check_box = static_cast<QCheckBox *>(m_table->cellWidget(l_row,0));
         bool l_state = Qt::Checked == l_check_box->checkState();
-        myassert(l_row < (int)g_data->getChannelsSize());
+        myassert(l_row < static_cast<int>(g_data->getChannelsSize()));
         if(g_data->getChannelAt(l_row)->isVisible() != l_state)
         {
             l_found = true;

--- a/widgets/score/scoresegmentiterator.cpp
+++ b/widgets/score/scoresegmentiterator.cpp
@@ -34,19 +34,19 @@ void ScoreSegmentIterator::reset(ScoreWidget * p_score_widget, Channel * p_chann
     m_stave_height = m_score_widget->getStaveHeight();
     m_half_stave_height = m_score_widget->getStaveCenterY();
     m_num_rows = std::max((m_score_widget->height() - toInt(m_score_widget->m_boarder_Y * 2)) / m_stave_height, 1);
-    m_total_row_time = (double)(m_score_widget->width() - m_score_widget->m_boarder_X * 2) / m_score_widget->m_scale_X;
+    m_total_row_time = static_cast<double>(m_score_widget->width() - m_score_widget->m_boarder_X * 2) / m_score_widget->m_scale_X;
     m_total_page_time = m_total_row_time * m_num_rows;
     if(m_channel)
     {
         m_cur_time = m_channel->timeAtChunk(m_channel->currentChunk());
-        m_cur_page = (int)floor(m_cur_time / m_total_page_time);
+        m_cur_page = static_cast<int>(floor(m_cur_time / m_total_page_time));
         m_look_ahead_gap_time = m_score_widget->m_look_ahead_gap * m_total_page_time;
         m_look_ahead_time = m_cur_time + m_score_widget->m_look_ahead * m_total_page_time;
         m_look_behind_time = m_look_ahead_time - m_total_page_time;
         m_start_of_page_time = floor(m_cur_time / m_total_page_time) * m_total_page_time;
         m_cur_rel_page_time = m_cur_time - m_start_of_page_time;
         m_end_time = m_channel->totalTime();
-        m_num_pages = (int)ceil(m_end_time / m_total_page_time);
+        m_num_pages = static_cast<int>(ceil(m_end_time / m_total_page_time));
         m_end_of_last_page_time = m_num_pages * m_total_page_time;
         m_look_ahead_time2 = (m_cur_page == m_num_pages - 1) ? std::min(m_end_time, m_look_ahead_time) : m_look_ahead_time;
         m_look_ahead_time2 = (m_cur_page == 0) ? m_end_of_last_page_time : m_look_ahead_time2;
@@ -54,7 +54,7 @@ void ScoreSegmentIterator::reset(ScoreWidget * p_score_widget, Channel * p_chann
         //FIXME: The ending page isn't drawn correctly
         m_look_behind_time2 = (m_cur_page == 0) ? m_look_behind_time + m_total_page_time : m_look_behind_time2;
         m_look_behind_time3 = std::min(m_look_behind_time, m_end_time - m_total_page_time);
-        m_cur_row = (int)floor(m_cur_rel_page_time / m_total_row_time);
+        m_cur_row = static_cast<int>(floor(m_cur_rel_page_time / m_total_row_time));
     }
     m_row_counter = 0;
     m_sub_row_counter = -1;
@@ -84,7 +84,7 @@ bool ScoreSegmentIterator::next()
                             //draw any parts of the next page
                             m_left_time = l_start_of_row_time + m_total_page_time;
                             m_right_time = std::min(l_end_of_row_time, m_look_behind_time3) + m_total_page_time;
-                            m_left_X = (double)m_score_widget->m_boarder_X;
+                            m_left_X = static_cast<double>(m_score_widget->m_boarder_X);
                             return (m_is_valid = true);
                         }
                     break;
@@ -94,7 +94,7 @@ bool ScoreSegmentIterator::next()
                             //normal case
                             m_left_time = std::max(l_start_of_row_time, m_look_behind_time3 + m_look_ahead_gap_time);
                             m_right_time = std::min(l_start_of_row_time + m_total_row_time, m_look_ahead_time2);
-                            m_left_X = (double)m_score_widget->m_boarder_X + (m_left_time - l_start_of_row_time) * m_score_widget->m_scale_X;
+                            m_left_X = static_cast<double>(m_score_widget->m_boarder_X) + (m_left_time - l_start_of_row_time) * m_score_widget->m_scale_X;
                             return (m_is_valid = true);
                         }
                         break;
@@ -104,7 +104,7 @@ bool ScoreSegmentIterator::next()
                             m_left_time = std::max(l_start_of_row_time - m_total_page_time, m_look_behind_time2 + m_look_ahead_gap_time);
                             m_left_time = std::min(m_left_time, l_end_of_row_time - m_total_page_time);
                             m_right_time = l_end_of_row_time - m_total_page_time;
-                            m_left_X = (double)m_score_widget->m_boarder_X + (m_left_time -(l_start_of_row_time - m_total_page_time)) * m_score_widget->m_scale_X;
+                            m_left_X = static_cast<double>(m_score_widget->m_boarder_X) + (m_left_time -(l_start_of_row_time - m_total_page_time)) * m_score_widget->m_scale_X;
                             return (m_is_valid = true);
                         }
                 }

--- a/widgets/score/scorewidget.cpp
+++ b/widgets/score/scorewidget.cpp
@@ -216,7 +216,7 @@ void ScoreWidget::drawNoteAtPitch( int p_x
     if(m_use_flats)
     {
         l_y_Steps = m_flats_lookup[p_pitch];
-        l_y_offset = toInt(m_scale_Y * (double)l_y_Steps * 0.5);
+        l_y_offset = toInt(m_scale_Y * static_cast<double>(l_y_Steps) * 0.5);
         if(isBlackNote(p_pitch))
         {
             get_painter().drawText(p_x - l_accidental_offset_X - m_font_width, p_y - l_y_offset + m_font_height / 2, "b");
@@ -225,7 +225,7 @@ void ScoreWidget::drawNoteAtPitch( int p_x
     else
     {
         l_y_Steps = m_sharps_lookup[p_pitch];
-        l_y_offset = toInt(m_scale_Y * (double)l_y_Steps * 0.5);
+        l_y_offset = toInt(m_scale_Y * static_cast<double>(l_y_Steps) * 0.5);
         if(isBlackNote(p_pitch))
         {
             get_painter().drawText(p_x - l_accidental_offset_X - m_font_width, p_y - l_y_offset + m_font_height / 2, "#");
@@ -400,10 +400,10 @@ void ScoreWidget::mousePressEvent(QMouseEvent *p_event)
     {
         while(l_score_segment_iterator.next())
         {
-            if(between(p_event->x(), (int)l_score_segment_iterator.leftX(), (int)(l_score_segment_iterator.leftX()+l_score_segment_iterator.widthX())) &&
+            if(between(p_event->x(), static_cast<int>(l_score_segment_iterator.leftX()), static_cast<int>(l_score_segment_iterator.leftX()+l_score_segment_iterator.widthX())) &&
 	           between(p_event->y(), l_score_segment_iterator.staveTop(), l_score_segment_iterator.staveBottom()))
             {
-                double l_t = l_score_segment_iterator.leftTime() + ((double)p_event->x() - l_score_segment_iterator.leftX()) / m_scale_X;
+                double l_t = l_score_segment_iterator.leftTime() + (static_cast<double>(p_event->x()) - l_score_segment_iterator.leftX()) / m_scale_X;
 
                 //Find the last note played at time l_t
                 int l_chunk = l_active_channel->chunkAtTime(l_t);

--- a/widgets/summary/summarydrawwidget.cpp
+++ b/widgets/summary/summarydrawwidget.cpp
@@ -64,14 +64,14 @@ void SummaryDrawWidget::paintEvent(QPaintEvent *)
     beginDrawing();
 
     //draw all the channels
-    for(int l_j = 0; l_j < (int)g_data->getChannelsSize(); l_j++)
+    for(int l_j = 0; l_j < static_cast<int>(g_data->getChannelsSize()); l_j++)
     {
         l_channel = g_data->getChannelAt(l_j);
         if(!l_channel->isVisible())
         {
             continue;
         }
-        drawChannel(*this, l_channel, get_painter(), g_data->leftTime(), l_view.currentTime(), (g_data->totalTime() / (double) width()), 0.0f, (double) g_data->topPitch() / (double) height(), DRAW_VIEW_SUMMARY);
+        drawChannel(*this, l_channel, get_painter(), g_data->leftTime(), l_view.currentTime(), (g_data->totalTime() / static_cast<double>(width())), 0.0f, static_cast<double>(g_data->topPitch()) / static_cast<double>(height()), DRAW_VIEW_SUMMARY);
     }
 
     //draw the view rectangle

--- a/widgets/vibrato/vibratocirclewidget.cpp
+++ b/widgets/vibrato/vibratocirclewidget.cpp
@@ -78,7 +78,7 @@ void VibratoCircleWidget::resizeGL(int p_width
 		                          ,int p_height
 		                          )
 {
-	glViewport(0, 0, (GLint)p_width, (GLint)p_height);
+	glViewport(0, 0, static_cast<GLint>(p_width), static_cast<GLint>(p_height));
 
 	glMatrixMode(GL_PROJECTION);
 	glLoadIdentity();
@@ -111,7 +111,7 @@ void VibratoCircleWidget::resizeGL(int p_width
 	glBegin(GL_LINE_LOOP);
 	for(int l_index = 0; l_index < 360; l_index = l_index + 1)
 	{
-		float l_deg_in_rad = (float)l_index * l_DEG2RAD;
+		float l_deg_in_rad = static_cast<float>(l_index) * l_DEG2RAD;
 		glVertex2f(l_half_width + 0.8 * l_half_width * cos(l_deg_in_rad), l_half_height + 0.8 * l_half_height * sin(l_deg_in_rad));
 	}
 	glEnd();
@@ -276,10 +276,10 @@ void VibratoCircleWidget::doUpdate()
 					l_vertices_counter = 0;
 					l_colors_counter = 0;
 
-					int l_end_i = std::min((l_current_chunk + 1) * l_active_channel->framesPerChunk() + l_smooth_delay, (int)l_pitch_lookup_used.size());
+					int l_end_i = std::min((l_current_chunk + 1) * l_active_channel->framesPerChunk() + l_smooth_delay, static_cast<int>(l_pitch_lookup_used.size()));
 					for(int l_index = l_right_minimum_time; l_index < l_end_i; l_index += l_step_size)
 					{
-						if(l_index > (int)l_pitch_lookup_used.size())
+						if(l_index > static_cast<int>(l_pitch_lookup_used.size()))
 						{
 							// Break out of loop when end of smoothed pitchlookup is reached
 							break;

--- a/widgets/vibrato/vibratoperiodwidget.cpp
+++ b/widgets/vibrato/vibratoperiodwidget.cpp
@@ -87,7 +87,7 @@ void VibratoPeriodWidget::resizeGL(int p_width
 		                          ,int p_height
 		                          )
 {
-	glViewport(0, 0, (GLint)p_width, (GLint)p_height);
+	glViewport(0, 0, static_cast<GLint>(p_width), static_cast<GLint>(p_height));
 
 	glMatrixMode(GL_PROJECTION);
 	glLoadIdentity();

--- a/widgets/vibrato/vibratospeedwidget.cpp
+++ b/widgets/vibrato/vibratospeedwidget.cpp
@@ -91,7 +91,7 @@ void VibratoSpeedWidget::resizeGL(int p_width
                                  ,int p_height
                                  )
 {
-    glViewport(0, 0, (GLint)p_width, (GLint)p_height);
+    glViewport(0, 0, static_cast<GLint>(p_width), static_cast<GLint>(p_height));
 
     glMatrixMode(GL_PROJECTION);
     glLoadIdentity();
@@ -557,7 +557,7 @@ void VibratoSpeedWidget::doUpdate()
                 if ((l_maximum_time !=0 ) && (l_minimum_time != 0))
                 {
                     // The speed and width can be calculated
-                    l_vibrato_speed = l_active_channel->rate() / (float)(2 * abs(l_maximum_time - l_minimum_time));
+                    l_vibrato_speed = l_active_channel->rate() / static_cast<float>(2 * abs(l_maximum_time - l_minimum_time));
                     l_vibrato_width = fabs(100 * (l_pitch_lookup_used.at(l_maximum_time) - l_pitch_lookup_used.at(l_minimum_time)));
                 }
             }

--- a/widgets/vibrato/vibratotunerwidget.cpp
+++ b/widgets/vibrato/vibratotunerwidget.cpp
@@ -82,7 +82,7 @@ void VibratoTunerWidget::resizeGL( int p_width
                                  , int p_height
                                  )
 {
-    glViewport(0, 0, (GLint)p_width, (GLint)p_height);
+    glViewport(0, 0, static_cast<GLint>(p_width), static_cast<GLint>(p_height));
 
     glMatrixMode(GL_PROJECTION);
     glLoadIdentity();
@@ -148,19 +148,19 @@ void VibratoTunerWidget::resizeGL( int p_width
     // Calculate line markings & text labels
     float l_step = (2 * l_theta) / 12.0;
     m_tuner_label_counter = 0;
-    char * l_tuner_label_lookup[11] =
+    const char * l_tuner_label_lookup[11] =
     {
-        (char*)"+50   ",
-        (char*)"+40",
-        (char*)"+30",
-        (char*)"+20",
-        (char*)"+10",
-        (char*)"0",
-        (char*)"-10",
-        (char*)"-20",
-        (char*)"-30",
-        (char*)"-40",
-        (char*)"   -50"
+        "+50   ",
+        "+40",
+        "+30",
+        "+20",
+        "+10",
+        "0",
+        "-10",
+        "-20",
+        "-30",
+        "-40",
+        "   -50"
     };
 
     for (int l_j = 0; l_j < 11; l_j++)
@@ -200,8 +200,8 @@ void VibratoTunerWidget::resizeGL( int p_width
         {
             // Big dial
             // Bigger marking + text label
-            l_tuner_label_lookup[0] = (char*)"+50";
-            l_tuner_label_lookup[10] = (char*)"-50";
+            l_tuner_label_lookup[0] = "+50";
+            l_tuner_label_lookup[10] = "-50";
 
             glBegin(GL_LINES);
             glColor3ub(0, 0, 0);

--- a/widgets/vibrato/vibratowidget.cpp
+++ b/widgets/vibrato/vibratowidget.cpp
@@ -85,7 +85,7 @@ void VibratoWidget::initializeGL()
 //------------------------------------------------------------------------------
 void VibratoWidget::resizeGL(int w, int h)
 {
-  glViewport(0, 0, (GLint)w, (GLint)h);
+  glViewport(0, 0, static_cast<GLint>(w), static_cast<GLint>(h));
 
   glMatrixMode(GL_PROJECTION);
   glLoadIdentity();
@@ -306,7 +306,7 @@ void VibratoWidget::doUpdate()
 
 	      for(int l_index = 0; l_index < l_color1_bars; l_index++)
 		{
-		  l_x1 = ((((float)l_note->get_maxima()->at(l_index) - l_smooth_delay) / l_frames_per_chunk) - l_my_start_chunk) * m_zoom_factor_X - l_window_offset;
+		  l_x1 = (((static_cast<float>(l_note->get_maxima()->at(l_index)) - l_smooth_delay) / l_frames_per_chunk) - l_my_start_chunk) * m_zoom_factor_X - l_window_offset;
 		  if (l_x1 < m_note_label_offset)
 		    {
 		      l_x1 = m_note_label_offset;
@@ -317,11 +317,11 @@ void VibratoWidget::doUpdate()
 		    }
 		  if (l_maximum_first)
 		    {
-		      l_x2 = ((((float)l_note->get_minima()->at(l_index) - l_smooth_delay) / l_frames_per_chunk) - l_my_start_chunk) * m_zoom_factor_X - l_window_offset;
+		      l_x2 = (((static_cast<float>(l_note->get_minima()->at(l_index)) - l_smooth_delay) / l_frames_per_chunk) - l_my_start_chunk) * m_zoom_factor_X - l_window_offset;
 		    }
 		  else
 		    {
-		      l_x2 = ((((float)l_note->get_minima()->at(l_index + 1) - l_smooth_delay) / l_frames_per_chunk) - l_my_start_chunk) * m_zoom_factor_X - l_window_offset;
+		      l_x2 = (((static_cast<float>(l_note->get_minima()->at(l_index + 1)) - l_smooth_delay) / l_frames_per_chunk) - l_my_start_chunk) * m_zoom_factor_X - l_window_offset;
 		    }
 		  if (l_x2 < m_note_label_offset)
 		    {
@@ -356,7 +356,7 @@ void VibratoWidget::doUpdate()
 
 	      for(int l_index = 0; l_index < l_color2_bars; l_index++)
 		{
-		  l_x1 = ((((float)l_note->get_minima()->at(l_index) - l_smooth_delay) / l_frames_per_chunk) - l_my_start_chunk) * m_zoom_factor_X - l_window_offset;
+		  l_x1 = (((static_cast<float>(l_note->get_minima()->at(l_index)) - l_smooth_delay) / l_frames_per_chunk) - l_my_start_chunk) * m_zoom_factor_X - l_window_offset;
 		  if (l_x1 < m_note_label_offset)
 		    {
 		      l_x1 = m_note_label_offset;
@@ -367,11 +367,11 @@ void VibratoWidget::doUpdate()
 		    }
 		  if (l_maximum_first)
 		    {
-		      l_x2 = ((((float)l_note->get_maxima()->at(l_index + 1) - l_smooth_delay) / l_frames_per_chunk) - l_my_start_chunk) * m_zoom_factor_X - l_window_offset;
+		      l_x2 = (((static_cast<float>(l_note->get_maxima()->at(l_index + 1)) - l_smooth_delay) / l_frames_per_chunk) - l_my_start_chunk) * m_zoom_factor_X - l_window_offset;
 		    }
 		  else
 		    {
-		      l_x2 = ((((float)l_note->get_maxima()->at(l_index) - l_smooth_delay) / l_frames_per_chunk) - l_my_start_chunk) * m_zoom_factor_X - l_window_offset;
+		      l_x2 = (((static_cast<float>(l_note->get_maxima()->at(l_index)) - l_smooth_delay) / l_frames_per_chunk) - l_my_start_chunk) * m_zoom_factor_X - l_window_offset;
 		    }
 		  if (l_x2 < m_note_label_offset)
 		    {
@@ -418,7 +418,7 @@ void VibratoWidget::doUpdate()
 
 	      for(int l_index = 0; l_index < l_maxima_size; l_index++)
 		{
-		  l_x1 = ((((float)l_note->get_maxima()->at(l_index) - l_smooth_delay) / l_frames_per_chunk) - l_my_start_chunk) * m_zoom_factor_X - l_window_offset;
+		  l_x1 = (((static_cast<float>(l_note->get_maxima()->at(l_index)) - l_smooth_delay) / l_frames_per_chunk) - l_my_start_chunk) * m_zoom_factor_X - l_window_offset;
 		  if (l_x1 < m_note_label_offset)
 		    {
 		      continue;
@@ -444,7 +444,7 @@ void VibratoWidget::doUpdate()
 	      // Calculate the vertical separator lines through the minima
 	      for(int l_index = 0; l_index < l_minima_size; l_index++)
 		{
-		  l_x1 = ((((float)l_note->get_minima()->at(l_index) - l_smooth_delay) / l_frames_per_chunk) - l_my_start_chunk) * m_zoom_factor_X - l_window_offset;
+		  l_x1 = (((static_cast<float>(l_note->get_minima()->at(l_index)) - l_smooth_delay) / l_frames_per_chunk) - l_my_start_chunk) * m_zoom_factor_X - l_window_offset;
 		  if (l_x1 < m_note_label_offset)
 		    {
 		      continue;
@@ -704,7 +704,7 @@ void VibratoWidget::doUpdate()
 			  int l_time_at_zero = l_beginning_of_note + l_smooth_delay;
 			  float l_scale_X = (l_offset - l_time_at_zero) / float(2 * l_smooth_delay);
 			  float l_pitch_at_zero = l_active->dataAtChunk(l_my_start_chunk)->getPitch();
-			  int l_smooth_delay_pos3 = std::min(l_beginning_of_note + 3 * l_smooth_delay, (int)l_pitch_lookup_used.size() - 1);
+			  int l_smooth_delay_pos3 = std::min(l_beginning_of_note + 3 * l_smooth_delay, static_cast<int>(l_pitch_lookup_used.size()) - 1);
 			  if(l_smooth_delay_pos3 >= 0)
 			    {
 			      float l_pitch_at_2_smooth_delay = l_pitch_lookup_used.at(l_smooth_delay_pos3);
@@ -778,7 +778,7 @@ void VibratoWidget::doUpdate()
 	  l_vertices_counter = 0;
 	  l_colors_counter = 0;
 
-	  const double l_half_window_time = (double)l_active->size() / (double)(l_active->rate() * 2);
+	  const double l_half_window_time = static_cast<double>(l_active->size()) / static_cast<double>(l_active->rate() * 2);
 	  int l_pixel_left = toInt((l_active->chunkAtTime(g_data->getView().currentTime() - l_half_window_time) - l_my_start_chunk) * m_zoom_factor_X - l_window_offset);
 	  int l_pixel_right = toInt((l_active->chunkAtTime(g_data->getView().currentTime() + l_half_window_time) - l_my_start_chunk) * m_zoom_factor_X - l_window_offset);
 
@@ -852,7 +852,7 @@ void VibratoWidget::doUpdate()
 	      float l_x, l_y;
 	      for(int l_index = 0; l_index < l_maxima_size; l_index++)
 		{
-		  l_x = ((((float)l_note->get_maxima()->at(l_index) - l_smooth_delay)/ l_frames_per_chunk) - l_my_start_chunk) * m_zoom_factor_X - l_window_offset;
+		  l_x = (((static_cast<float>(l_note->get_maxima()->at(l_index)) - l_smooth_delay)/ l_frames_per_chunk) - l_my_start_chunk) * m_zoom_factor_X - l_window_offset;
 		  if (l_x < m_note_label_offset)
 		    {
 		      continue;
@@ -877,7 +877,7 @@ void VibratoWidget::doUpdate()
 	      float l_x, l_y;
 	      for(int l_index = 0; l_index < l_minima_size; l_index++)
 		{
-		  l_x = ((((float)l_note->get_minima()->at(l_index) - l_smooth_delay) / l_frames_per_chunk) - l_my_start_chunk) * m_zoom_factor_X - l_window_offset;
+		  l_x = (((static_cast<float>(l_note->get_minima()->at(l_index)) - l_smooth_delay) / l_frames_per_chunk) - l_my_start_chunk) * m_zoom_factor_X - l_window_offset;
 		  if (l_x < m_note_label_offset)
 		    {
 		      continue;


### PR DESCRIPTION
- Replaced all C-style casts with `static_cast<>`
- Many of these casts may not be needed, but I left them unchanged to avoid introducing any subtle bugs
- It is now easier to find and review all of the casts in the code