### PR TITLE
Clean up `MusicScale` class

### DIFF
--- a/general/music_scale.cpp
+++ b/general/music_scale.cpp
@@ -16,6 +16,26 @@
  ***************************************************************************/
 
 #include "music_scale.h"
+#include "myassert.h"
+
+//------------------------------------------------------------------------------
+MusicScale::MusicScale( const std::string & p_name
+                      , ScaleType p_scale_type
+                      , const std::vector<int> & p_notes
+                      , int p_semitone_offset
+                      )
+: m_name(p_name)
+, m_scale_type(p_scale_type)
+, m_notes(p_notes)
+, m_semitone_lookup(12, false)
+, m_semitone_offset(p_semitone_offset)
+{
+    for(int l_note : m_notes)
+    {
+        myassert(l_note >= 0 && l_note < 12);
+        m_semitone_lookup[l_note] = true;
+    }
+}
 
 //------------------------------------------------------------------------------
 MusicScale::~MusicScale()
@@ -23,23 +43,35 @@ MusicScale::~MusicScale()
 }
 
 //------------------------------------------------------------------------------
-void MusicScale::addScale( const std::string & p_name
-        , const int * p_notes
-        , int p_length
-        , int p_semitone_offset
-                         )
+const MusicScale & MusicScale::getScale(ScaleType p_scale_type)
 {
-    m_p_notes.resize_copy(p_notes, p_length);
-    m_p_semitone_lookup.resize(12, false);
-    for(int l_j = 0; l_j < p_length; l_j++)
-    {
-        myassert(p_notes[l_j] >= 0 && p_notes[l_j] < 12);
-        m_p_semitone_lookup[p_notes[l_j]] = true;
-    }
-    m_name = p_name;
-    m_semitone_offset = p_semitone_offset;
+    return g_music_scales[static_cast<int>(p_scale_type)];
 }
 
-std::vector<MusicScale> g_music_scales;
+//------------------------------------------------------------------------------
+bool MusicScale::isMajorScaleNote(int p_note)
+{
+    return getScale(ScaleType::Major).hasSemitone(p_note);
+}
+
+//------------------------------------------------------------------------------
+void MusicScale::init()
+{
+    const std::vector<int> l_all_note_scale = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
+    const std::vector<int> l_major_scale                    = {0, 2, 4, 5, 7, 9, 11 };
+    const std::vector<int> l_natural_minor_scale            = {0, 2, 3, 5, 7, 8, 10 };
+    const std::vector<int> l_harmonic_minor_scale           = {0, 2, 3, 5, 7, 8, 11 };
+    const std::vector<int> l_ascending_melodic_minor_scale  = {0, 2, 3, 5, 7, 9, 11 };
+    
+    g_music_scales =
+    { MusicScale("All Notes", ScaleType::Chromatic, l_all_note_scale)
+    , MusicScale("Major", ScaleType::Major, l_major_scale)
+    , MusicScale("Minor (Natural)", ScaleType::NaturalMinor, l_natural_minor_scale)
+    , MusicScale("Minor (Harmonic)", ScaleType::HarmonicMinor, l_harmonic_minor_scale)
+    , MusicScale("Minor (Ascending Melodic)", ScaleType::MelodicMinor, l_ascending_melodic_minor_scale)
+    };
+}
+
+std::vector<MusicScale> MusicScale::g_music_scales;
 
 // EOF

--- a/general/music_scale.h
+++ b/general/music_scale.h
@@ -18,14 +18,14 @@
 #ifndef TARTINI_MUSIC_SCALE_H
 #define TARTINI_MUSIC_SCALE_H
 
-#include "array1d.h"
+#include "music_key.h"
 #include <vector>
 
 class MusicScale
 {
   public:
 
-    enum MusicScale_t
+    enum class ScaleType
     { Chromatic
     , Major
     , NaturalMinor
@@ -33,33 +33,40 @@ class MusicScale
     , MelodicMinor
     };
 
-    inline MusicScale();
+    MusicScale( const std::string & p_name
+              , ScaleType p_scale_type
+              , const std::vector<int> & p_notes
+              , int p_semitone_offset = 0
+              );
     ~MusicScale();
 
-    void addScale( const std::string & p_name
-                 , const int * p_notes
-                 , int p_length
-                 , int p_semitone_offset
-                 );
-
+    inline ScaleType scaleType()const;
     inline int size()const;
     inline int note(int j)const;
     inline bool hasSemitone(int p_j)const;
     inline const std::string & name()const;
     inline int semitoneOffset()const;
+    inline bool isChromaticScale()const;
+    inline bool isMinorScale()const;
+    inline bool isCompatibleWithTemparament(MusicKey::TemparamentType p_temparament_type)const;
 
-  private:
+    static void init();
+    static inline const std::vector<MusicScale> & getScales();
+    static const MusicScale & getScale(ScaleType p_scale_type);
+    static bool isMajorScaleNote(int p_note);
 
-    Array1d<int> m_p_notes;
-    std::vector<bool> m_p_semitone_lookup;
+private:
+
     std::string m_name;
+    ScaleType m_scale_type;
+    std::vector<int> m_notes;
+    std::vector<bool> m_semitone_lookup;
     int m_semitone_offset;
-
+    
+    static std::vector<MusicScale> g_music_scales;
 };
 
 #include "music_scale.hpp"
-
-extern std::vector<MusicScale> g_music_scales;
 
 #endif //TARTINI_MUSIC_SCALE_H
 // EOF

--- a/general/music_scale.hpp
+++ b/general/music_scale.hpp
@@ -15,25 +15,24 @@
    Please read LICENSE.txt for details.
  ***************************************************************************/
 //------------------------------------------------------------------------------
-MusicScale::MusicScale()
-: m_name()
-, m_semitone_offset(0)
+MusicScale::ScaleType MusicScale::scaleType()const
 {
+    return m_scale_type;
 }
 
 //------------------------------------------------------------------------------
 int MusicScale::size()const
 {
-    return m_p_notes.size();
+    return m_notes.size();
 }
 
 //------------------------------------------------------------------------------
 int MusicScale::note(int j)const
 {
 #ifdef MYDEBUG
-    return m_p_notes.at(j);
+    return m_notes.at(j);
 #else // MYDEBUG
-    return m_p_notes[j];
+    return m_notes[j];
 #endif // MYDEBUG
 }
 
@@ -41,9 +40,9 @@ int MusicScale::note(int j)const
 bool MusicScale::hasSemitone(int p_j)const
 {
 #ifdef MYDEBUG
-    return m_p_semitone_lookup.at(p_j);
+    return m_semitone_lookup.at(p_j);
 #else // MYDEBUG
-    return m_p_semitone_lookup[p_j];
+    return m_semitone_lookup[p_j];
 #endif // MYDEBUG
 }
 
@@ -57,6 +56,40 @@ const std::string & MusicScale::name()const
 int MusicScale::semitoneOffset()const
 {
     return m_semitone_offset;
+}
+
+//------------------------------------------------------------------------------
+bool MusicScale::isChromaticScale()const
+{
+    return m_scale_type == ScaleType::Chromatic;
+}
+
+//------------------------------------------------------------------------------
+bool MusicScale::isMinorScale()const
+{
+    switch(m_scale_type)
+    {
+        case ScaleType::Chromatic:
+        case ScaleType::Major:
+            return false;
+            
+        case ScaleType::NaturalMinor:
+        case ScaleType::HarmonicMinor:
+        case ScaleType::MelodicMinor:
+            return true;
+    }
+}
+
+//------------------------------------------------------------------------------
+bool MusicScale::isCompatibleWithTemparament(MusicKey::TemparamentType p_temparament_type)const
+{
+    return (p_temparament_type == MusicKey::TemparamentType::Even || !isMinorScale());
+}
+
+//------------------------------------------------------------------------------
+const std::vector<MusicScale> & MusicScale::getScales()
+{
+    return g_music_scales;
 }
 
 // EOF

--- a/general/musicnotes.cpp
+++ b/general/musicnotes.cpp
@@ -60,18 +60,7 @@ void initMusicStuff()
 {
     music_notes::init_note_names();
     MusicKey::init();
-
-    int l_all_note_scale[12] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
-    int l_major_scale[7]                   = {0, 2, 4, 5, 7, 9, 11 };
-    int l_natural_minor_scale[7]           = {0, 2, 3, 5, 7, 8, 10 };
-    int l_harmonic_minor_scale[7]          = {0, 2, 3, 5, 7, 8, 11 };
-    int l_ascending_melodic_minor_scale[7] = {0, 2, 3, 5, 7, 9, 11 };
-    g_music_scales.resize(5);
-    g_music_scales[MusicScale::Chromatic].addScale("All Notes", l_all_note_scale, 12, 0);
-    g_music_scales[MusicScale::Major].addScale("Major", l_major_scale, 7, 0);
-    g_music_scales[MusicScale::NaturalMinor].addScale("Minor (Natural)", l_natural_minor_scale, 7, 0);
-    g_music_scales[MusicScale::HarmonicMinor].addScale("Minor (Harmonic)", l_harmonic_minor_scale, 7, 0);
-    g_music_scales[MusicScale::MelodicMinor].addScale("Minor (Ascending Melodic)", l_ascending_melodic_minor_scale, 7, 0);
+    MusicScale::init();
 }
 
 /**

--- a/global/gdata.cpp
+++ b/global/gdata.cpp
@@ -135,7 +135,7 @@ GData::GData()
 , m_saving_mode(SavingModes::ALWAYS_ASK)
 , m_vibrato_sine_style(false)
 , m_music_key(3) // C
-, m_music_key_type(0) //ALL_NOTES
+, m_music_key_type(MusicScale::ScaleType::Chromatic) //ALL_NOTES
 , m_tempered_type(0) //EVEN_TEMPERED
 , m_mouse_wheel_zooms(false)
 , m_freq_A(440)
@@ -968,26 +968,10 @@ void GData::setTemperedType(int p_type)
 {
     if(m_tempered_type != p_type)
     {
-        if(m_tempered_type == 0 && p_type > 0)
+        // If the current key type is not compatible with the new tempered type, then set the key type to Chromatic.
+        if(!MusicScale::getScale(m_music_key_type).isCompatibleWithTemparament(static_cast<MusicKey::TemparamentType>(p_type)))
         {
-            //remove out the minors
-            if(m_music_key_type >= 2)
-            {
-                setMusicKeyType(0);
-            }
-            for(int l_j = g_music_scales.size() - 1; l_j >= 2; l_j--)
-            {
-                g_main_window->remove_key_type(l_j);
-            }
-        }
-        else if(m_tempered_type > 0 && p_type == 0)
-        {
-            QStringList l_string_list;
-            for(unsigned int l_j = 2; l_j < g_music_scales.size(); l_j++)
-            {
-                l_string_list << g_music_scales[l_j].name().c_str();
-            }
-            g_main_window->add_key_types(l_string_list);
+            setMusicKeyType(MusicScale::ScaleType::Chromatic);
         }
         m_tempered_type = p_type; emit temperedTypeChanged(p_type);
     }

--- a/global/gdata.h
+++ b/global/gdata.h
@@ -44,6 +44,7 @@
 #include "useful.h"
 #include "view.h"
 #include "analysisdata.h"
+#include "music_scale.h"
 
 #ifndef WINDOWS
 //for multi-threaded profiling
@@ -276,7 +277,7 @@ class GData : public QObject
   inline void set_rms_ceiling(const double &);
 
   inline int musicKey()const;
-  inline int musicKeyType()const;
+  inline MusicScale::ScaleType musicKeyType()const;
   inline int temperedType()const;
   inline const double & freqA()const;
   inline const double & semitoneOffset()const;
@@ -309,6 +310,7 @@ public slots:
 
   inline void setMusicKey(int p_key);
   inline void setMusicKeyType(int p_type);
+  inline void setMusicKeyType(MusicScale::ScaleType p_type);
   void setTemperedType(int p_type);
   void setFreqA(double p_x);
   inline void setFreqA(int p_x);
@@ -416,7 +418,7 @@ public slots:
   t_saving_modes m_saving_mode;
   bool m_vibrato_sine_style;
   int m_music_key;
-  int m_music_key_type;
+  MusicScale::ScaleType m_music_key_type;
   int m_tempered_type;
   bool m_mouse_wheel_zooms;
   double m_freq_A;

--- a/global/gdata.hpp
+++ b/global/gdata.hpp
@@ -522,7 +522,7 @@ int GData::musicKey()const
 }
 
 //------------------------------------------------------------------------------
-int GData::musicKeyType()const
+MusicScale::ScaleType GData::musicKeyType()const
 {
     return m_music_key_type;
 }
@@ -558,10 +558,16 @@ void GData::setMusicKey(int p_key)
 //------------------------------------------------------------------------------
 void GData::setMusicKeyType(int p_type)
 {
+    setMusicKeyType(static_cast<MusicScale::ScaleType>(p_type));
+}
+
+//------------------------------------------------------------------------------
+void GData::setMusicKeyType(MusicScale::ScaleType p_type)
+{
     if(m_music_key_type != p_type)
     {
         m_music_key_type = p_type;
-        emit musicKeyTypeChanged(p_type);
+        emit musicKeyTypeChanged(static_cast<int>(p_type));
     }
 }
 

--- a/widgets/freq/freqwidgetGL.cpp
+++ b/widgets/freq/freqwidgetGL.cpp
@@ -200,7 +200,7 @@ void FreqWidgetGL::drawReferenceLinesGL( const double & /* p_left_time*/
 #endif // QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
 
     const MusicKey &l_music_key = MusicKey::getKeys()[GData::getUniqueInstance().temperedType()];
-    const MusicScale &l_music_scale = g_music_scales[GData::getUniqueInstance().musicKeyType()];
+    const MusicScale &l_music_scale = MusicScale::getScale(GData::getUniqueInstance().musicKeyType());
 
     int l_key_root = cycle(g_music_key_root[GData::getUniqueInstance().musicKey()] + l_music_scale.semitoneOffset(), 12);
     int l_view_bottom_note = static_cast<int>(p_view_bottom) - l_key_root;
@@ -234,7 +234,7 @@ void FreqWidgetGL::drawReferenceLinesGL( const double & /* p_left_time*/
                     glColor4ub(0, 0, 0, 128);
                     mygl_line(l_font_width, l_line_Y, width() - 1, l_line_Y);
                 }
-                else if((GData::getUniqueInstance().musicKeyType() == MusicScale::Chromatic) && !g_music_scales[MusicScale::Major].hasSemitone(l_music_key.noteType(l_j)))
+                else if(l_music_scale.isChromaticScale() && !MusicScale::isMajorScaleNote(l_music_key.noteType(l_j)))
                 {
                     glColor4ub(25, 125, 170, 128);
                     glEnable(GL_LINE_STIPPLE);

--- a/widgets/mainwindow/mainwindow.cpp
+++ b/widgets/mainwindow/mainwindow.cpp
@@ -460,13 +460,8 @@ MainWindow::MainWindow()
 
     m_key_type_combo_box = new QComboBox(l_key_tool_bar);
     m_key_type_combo_box->setWindowTitle(tr("Scale type"));
-    l_string_list.clear();
-    for(unsigned int l_j = 0; l_j < g_music_scales.size(); l_j++)
-    {
-        l_string_list << g_music_scales[l_j].name().c_str();
-    }
-    m_key_type_combo_box->addItems(l_string_list);
-    m_key_type_combo_box->setCurrentIndex(GData::getUniqueInstance().musicKeyType());
+    updateKeyTypes(GData::getUniqueInstance().temperedType());
+    m_key_type_combo_box->setCurrentIndex(static_cast<int>(GData::getUniqueInstance().musicKeyType()));
     l_key_tool_bar->addWidget(m_key_type_combo_box);
     connect(m_key_type_combo_box, SIGNAL(activated(int)), &GData::getUniqueInstance(), SLOT(setMusicKeyType(int)));
     connect(&GData::getUniqueInstance(), SIGNAL(musicKeyTypeChanged(int)), m_key_type_combo_box, SLOT(setCurrentIndex(int)));
@@ -483,6 +478,7 @@ MainWindow::MainWindow()
     l_tempered_combo_box->setCurrentIndex(GData::getUniqueInstance().temperedType());
     l_key_tool_bar->addWidget(l_tempered_combo_box);
     connect(l_tempered_combo_box, SIGNAL(activated(int)), &GData::getUniqueInstance(), SLOT(setTemperedType(int)));
+    connect(&GData::getUniqueInstance(), SIGNAL(temperedTypeChanged(int)), this, SLOT(updateKeyTypes(int)));
     connect(&GData::getUniqueInstance(), SIGNAL(temperedTypeChanged(int)), l_tempered_combo_box, SLOT(setCurrentIndex(int)));
     connect(&GData::getUniqueInstance(), SIGNAL(temperedTypeChanged(int)), &(GData::getUniqueInstance().getView()), SLOT(doUpdate()));
 
@@ -1392,17 +1388,22 @@ MainWindow::get_view_data(unsigned int p_index)
 
 //------------------------------------------------------------------------------
 void
-MainWindow::remove_key_type(int p_index)
+MainWindow::updateKeyTypes(int p_tempered_type)
 {
-    assert(p_index < m_key_type_combo_box->count());
-    m_key_type_combo_box->removeItem(p_index);
-}
-
-//------------------------------------------------------------------------------
-void
-MainWindow::add_key_types(const QStringList & p_list)
-{
-    m_key_type_combo_box->addItems(p_list);
+    // Update the list of key types based on the tempered type
+    QStringList l_string_list;
+    for(const MusicScale & l_music_scale : MusicScale::getScales())
+    {
+        //remove out the minors
+        if(l_music_scale.isCompatibleWithTemparament(static_cast<MusicKey::TemparamentType>(p_tempered_type)))
+        {
+            l_string_list << l_music_scale.name().c_str();
+        }
+    }
+    QString l_current_text = m_key_type_combo_box->currentText();
+    m_key_type_combo_box->clear();
+    m_key_type_combo_box->addItems(l_string_list);
+    m_key_type_combo_box->setCurrentText(l_current_text);
 }
 
 // EOF

--- a/widgets/mainwindow/mainwindow.h
+++ b/widgets/mainwindow/mainwindow.h
@@ -72,8 +72,6 @@ class MainWindow : public QMainWindow
 
     void keyPressEvent(QKeyEvent * p_event);
     void message(QString p_string, int p_msec);
-    void remove_key_type(int p_index);
-    void add_key_types(const QStringList & p_list);
 
   protected:
     bool event(QEvent * p_event);
@@ -97,6 +95,8 @@ class MainWindow : public QMainWindow
     void windowMenuAboutToShow();
     void windowMenuActivated();
     void newViewAboutToShow();
+
+    void updateKeyTypes(int p_tempered_type);
 
     /**
      * Opens a view based on a viewId (which should be #defined).


### PR DESCRIPTION
- Make `MusicScale` objects immutable
  - Expand constructor to initialize all members
- Use `std::vector` instead of `Array1d`
- Move initialization of class from `musicnotes.cpp` to static `init()` method
- Convert `g_music_scales` from global variable to private static member with accessor method
- Add helper methods `isChromaticScale`, `isMinorScale`, `isMajorScaleNote`, and `isCompatibleWithTemparament` to remove business logic from UI layer
- Change `GData::m_music_key_type` from `int` to `MusicScale::ScaleType`
- Remove logic from `GData::setTemperedType()` that removes and inserts items from the key types combo box
- Replace `MainWindow::remove_key_type()` and `MainWindow::add_key_types()` with `MainWindow::updateKeyTypes()`
- Connect the `temperedTypeChanged` signal to `MainWindow::updateKeyTypes()` to update the combo box items when the tempered type is changed