### PR TITLE
Fix confusing naming of "keys", "scales", and "temperaments"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,8 +135,8 @@ set(MY_HEADER_FILES
     include/RingBuffer.h
     general/music_scale.h
     general/music_scale.hpp
-    general/music_key.h
-    general/music_key.hpp
+    general/music_temperament.h
+    general/music_temperament.hpp
     dialogs/tartinidialog.h
     dialogs/gpldialog.h
     widgets/widget_utils.h
@@ -230,7 +230,7 @@ set(MY_SOURCE_FILES
     general/musicnotes.cpp
     general/myalgo.cpp
     general/music_scale.cpp
-    general/music_key.cpp
+    general/music_temperament.cpp
     dialogs/tartinidialog.cpp
     dialogs/gpldialog.cpp
    )

--- a/general/music_key.cpp
+++ b/general/music_key.cpp
@@ -129,17 +129,17 @@ std::vector<MusicKey> MusicKey::g_music_keys;
 
 const std::string g_music_key_name[NUM_MUSIC_KEYS] =
         {"A             ",
-         "A#/Bb",
+         "A♯/B♭",
          "B",
          "C",
-         "C#/Db",
+         "C♯/D♭",
          "D",
-         "D#/Eb",
+         "D♯/E♭",
          "E",
          "F",
-         "F#/Gb",
+         "F♯/G♭",
          "G",
-         "G#/Ab"
+         "G♯/A♭"
         };
 int g_music_key_root[NUM_MUSIC_KEYS] = { 9, 10, 11, 0, 1, 2, 3, 4, 5, 6, 7, 8 };
 

--- a/general/music_scale.cpp
+++ b/general/music_scale.cpp
@@ -16,6 +16,26 @@
  ***************************************************************************/
 
 #include "music_scale.h"
+#include "myassert.h"
+
+//------------------------------------------------------------------------------
+MusicScale::MusicScale( const std::string & p_name
+                      , ScaleType p_scale_type
+                      , const std::vector<int> & p_notes
+                      , int p_semitone_offset
+                      )
+: m_name(p_name)
+, m_scale_type(p_scale_type)
+, m_notes(p_notes)
+, m_semitone_lookup(12, false)
+, m_semitone_offset(p_semitone_offset)
+{
+    for(int l_note : m_notes)
+    {
+        myassert(l_note >= 0 && l_note < 12);
+        m_semitone_lookup[l_note] = true;
+    }
+}
 
 //------------------------------------------------------------------------------
 MusicScale::~MusicScale()
@@ -23,23 +43,35 @@ MusicScale::~MusicScale()
 }
 
 //------------------------------------------------------------------------------
-void MusicScale::addScale( const std::string & p_name
-        , const int * p_notes
-        , int p_length
-        , int p_semitone_offset
-                         )
+const MusicScale & MusicScale::getScale(ScaleType p_scale_type)
 {
-    m_p_notes.resize_copy(p_notes, p_length);
-    m_p_semitone_lookup.resize(12, false);
-    for(int l_j = 0; l_j < p_length; l_j++)
-    {
-        myassert(p_notes[l_j] >= 0 && p_notes[l_j] < 12);
-        m_p_semitone_lookup[p_notes[l_j]] = true;
-    }
-    m_name = p_name;
-    m_semitone_offset = p_semitone_offset;
+    return g_music_scales[static_cast<int>(p_scale_type)];
 }
 
-std::vector<MusicScale> g_music_scales;
+//------------------------------------------------------------------------------
+bool MusicScale::isMajorScaleNote(int p_note)
+{
+    return getScale(ScaleType::Major).hasSemitone(p_note);
+}
+
+//------------------------------------------------------------------------------
+void MusicScale::init()
+{
+    const std::vector<int> l_all_note_scale = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
+    const std::vector<int> l_major_scale                    = {0, 2, 4, 5, 7, 9, 11 };
+    const std::vector<int> l_natural_minor_scale            = {0, 2, 3, 5, 7, 8, 10 };
+    const std::vector<int> l_harmonic_minor_scale           = {0, 2, 3, 5, 7, 8, 11 };
+    const std::vector<int> l_ascending_melodic_minor_scale  = {0, 2, 3, 5, 7, 9, 11 };
+    
+    g_music_scales =
+    { MusicScale("All Notes", ScaleType::Chromatic, l_all_note_scale)
+    , MusicScale("Major", ScaleType::Major, l_major_scale)
+    , MusicScale("Minor (Natural)", ScaleType::NaturalMinor, l_natural_minor_scale)
+    , MusicScale("Minor (Harmonic)", ScaleType::HarmonicMinor, l_harmonic_minor_scale)
+    , MusicScale("Minor (Ascending Melodic)", ScaleType::MelodicMinor, l_ascending_melodic_minor_scale)
+    };
+}
+
+std::vector<MusicScale> MusicScale::g_music_scales;
 
 // EOF

--- a/general/music_scale.h
+++ b/general/music_scale.h
@@ -18,14 +18,14 @@
 #ifndef TARTINI_MUSIC_SCALE_H
 #define TARTINI_MUSIC_SCALE_H
 
-#include "array1d.h"
+#include "music_key.h"
 #include <vector>
 
 class MusicScale
 {
   public:
 
-    enum MusicScale_t
+    enum class ScaleType
     { Chromatic
     , Major
     , NaturalMinor
@@ -33,33 +33,40 @@ class MusicScale
     , MelodicMinor
     };
 
-    inline MusicScale();
+    MusicScale( const std::string & p_name
+              , ScaleType p_scale_type
+              , const std::vector<int> & p_notes
+              , int p_semitone_offset = 0
+              );
     ~MusicScale();
 
-    void addScale( const std::string & p_name
-                 , const int * p_notes
-                 , int p_length
-                 , int p_semitone_offset
-                 );
-
+    inline ScaleType scaleType()const;
     inline int size()const;
     inline int note(int j)const;
     inline bool hasSemitone(int p_j)const;
     inline const std::string & name()const;
     inline int semitoneOffset()const;
+    inline bool isChromaticScale()const;
+    inline bool isMinorScale()const;
+    inline bool isCompatibleWithTemparament(MusicKey::TemparamentType p_temparament_type)const;
 
-  private:
+    static void init();
+    static inline const std::vector<MusicScale> & getScales();
+    static const MusicScale & getScale(ScaleType p_scale_type);
+    static bool isMajorScaleNote(int p_note);
 
-    Array1d<int> m_p_notes;
-    std::vector<bool> m_p_semitone_lookup;
+private:
+
     std::string m_name;
+    ScaleType m_scale_type;
+    std::vector<int> m_notes;
+    std::vector<bool> m_semitone_lookup;
     int m_semitone_offset;
-
+    
+    static std::vector<MusicScale> g_music_scales;
 };
 
 #include "music_scale.hpp"
-
-extern std::vector<MusicScale> g_music_scales;
 
 #endif //TARTINI_MUSIC_SCALE_H
 // EOF

--- a/general/music_scale.h
+++ b/general/music_scale.h
@@ -18,7 +18,7 @@
 #ifndef TARTINI_MUSIC_SCALE_H
 #define TARTINI_MUSIC_SCALE_H
 
-#include "music_key.h"
+#include "music_temperament.h"
 #include <vector>
 
 class MusicScale
@@ -48,7 +48,7 @@ class MusicScale
     inline int semitoneOffset()const;
     inline bool isChromaticScale()const;
     inline bool isMinorScale()const;
-    inline bool isCompatibleWithTemparament(MusicKey::TemparamentType p_temparament_type)const;
+    inline bool isCompatibleWithTemparament(MusicTemperament::TemperamentType p_temparament_type)const;
 
     static void init();
     static inline const std::vector<MusicScale> & getScales();

--- a/general/music_scale.hpp
+++ b/general/music_scale.hpp
@@ -15,25 +15,24 @@
    Please read LICENSE.txt for details.
  ***************************************************************************/
 //------------------------------------------------------------------------------
-MusicScale::MusicScale()
-: m_name()
-, m_semitone_offset(0)
+MusicScale::ScaleType MusicScale::scaleType()const
 {
+    return m_scale_type;
 }
 
 //------------------------------------------------------------------------------
 int MusicScale::size()const
 {
-    return m_p_notes.size();
+    return m_notes.size();
 }
 
 //------------------------------------------------------------------------------
 int MusicScale::note(int j)const
 {
 #ifdef MYDEBUG
-    return m_p_notes.at(j);
+    return m_notes.at(j);
 #else // MYDEBUG
-    return m_p_notes[j];
+    return m_notes[j];
 #endif // MYDEBUG
 }
 
@@ -41,9 +40,9 @@ int MusicScale::note(int j)const
 bool MusicScale::hasSemitone(int p_j)const
 {
 #ifdef MYDEBUG
-    return m_p_semitone_lookup.at(p_j);
+    return m_semitone_lookup.at(p_j);
 #else // MYDEBUG
-    return m_p_semitone_lookup[p_j];
+    return m_semitone_lookup[p_j];
 #endif // MYDEBUG
 }
 
@@ -57,6 +56,40 @@ const std::string & MusicScale::name()const
 int MusicScale::semitoneOffset()const
 {
     return m_semitone_offset;
+}
+
+//------------------------------------------------------------------------------
+bool MusicScale::isChromaticScale()const
+{
+    return m_scale_type == ScaleType::Chromatic;
+}
+
+//------------------------------------------------------------------------------
+bool MusicScale::isMinorScale()const
+{
+    switch(m_scale_type)
+    {
+        case ScaleType::Chromatic:
+        case ScaleType::Major:
+            return false;
+            
+        case ScaleType::NaturalMinor:
+        case ScaleType::HarmonicMinor:
+        case ScaleType::MelodicMinor:
+            return true;
+    }
+}
+
+//------------------------------------------------------------------------------
+bool MusicScale::isCompatibleWithTemparament(MusicKey::TemparamentType p_temparament_type)const
+{
+    return (p_temparament_type == MusicKey::TemparamentType::Even || !isMinorScale());
+}
+
+//------------------------------------------------------------------------------
+const std::vector<MusicScale> & MusicScale::getScales()
+{
+    return g_music_scales;
 }
 
 // EOF

--- a/general/music_scale.hpp
+++ b/general/music_scale.hpp
@@ -81,9 +81,9 @@ bool MusicScale::isMinorScale()const
 }
 
 //------------------------------------------------------------------------------
-bool MusicScale::isCompatibleWithTemparament(MusicKey::TemparamentType p_temparament_type)const
+bool MusicScale::isCompatibleWithTemparament(MusicTemperament::TemperamentType p_temparament_type)const
 {
-    return (p_temparament_type == MusicKey::TemparamentType::Even || !isMinorScale());
+    return (p_temparament_type == MusicTemperament::TemperamentType::Even || !isMinorScale());
 }
 
 //------------------------------------------------------------------------------

--- a/general/music_temperament.cpp
+++ b/general/music_temperament.cpp
@@ -1,5 +1,5 @@
 /***************************************************************************
-                          music_scale.h
+                          music_temperament.cpp
                              -------------------
     begin                : 2002
     copyright            : (C) 2002-2005 by Philip McLeod
@@ -14,12 +14,12 @@
 
    Please read LICENSE.txt for details.
  ***************************************************************************/
-#include "music_key.h"
+#include "music_temperament.h"
 #include "musicnotes.h"
 
 //------------------------------------------------------------------------------
-MusicKey::MusicKey(const std::string & p_name
-                 , TemparamentType p_temparament_type
+MusicTemperament::MusicTemperament(const std::string & p_name
+                 , TemperamentType p_temparament_type
                  , NoteOffsetType p_note_offset_type
                  , const std::vector<double> & p_note_offsets
                  , const std::vector<int> & p_note_types
@@ -54,29 +54,29 @@ MusicKey::MusicKey(const std::string & p_name
 }
 
 //------------------------------------------------------------------------------
-MusicKey::~MusicKey()
+MusicTemperament::~MusicTemperament()
 {
 }
 
 //------------------------------------------------------------------------------
-int MusicKey::nearestNoteIndex(const double & p_x)const
+int MusicTemperament::nearestNoteIndex(const double & p_x)const
 {
     return static_cast<int>(binary_search_closest(m_note_offsets.begin(), m_note_offsets.end(), p_x) - m_note_offsets.begin());
 }
 
 //------------------------------------------------------------------------------
-double MusicKey::nearestNote(const double & p_x)const
+double MusicTemperament::nearestNote(const double & p_x)const
 {
     return *binary_search_closest(m_note_offsets.begin(), m_note_offsets.end(), p_x);
 }
 
 //------------------------------------------------------------------------------
-double MusicKey::nearestNoteDistance(const double & p_x)const
+double MusicTemperament::nearestNoteDistance(const double & p_x)const
 {
     return fabs(*binary_search_closest(m_note_offsets.begin(), m_note_offsets.end(), p_x) - p_x);
 }
 
-void MusicKey::init()
+void MusicTemperament::init()
 {
     const std::vector<double> l_even_tempered_scale =
         {0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0 };
@@ -96,36 +96,36 @@ void MusicKey::init()
     const std::vector<double> l_meantone_temperament_scale =
         {0, 76, 193, 310, 386, 503, 579, 697, 773, 890, 1007, 1083 };
 
-    g_music_keys.push_back(MusicKey("Even Tempered"
-                                  , TemparamentType::Even
+    g_music_temperaments.push_back(MusicTemperament("Even Tempered"
+                                  , TemperamentType::Even
                                   , NoteOffsetType::Midi
                                   , l_even_tempered_scale
                                   , l_twelve_note_type
                                     ));
 
-    g_music_keys.push_back(MusicKey("Just Intonation"
-                                  , TemparamentType::Just
+    g_music_temperaments.push_back(MusicTemperament("Just Intonation"
+                                  , TemperamentType::Just
                                   , NoteOffsetType::Ratio
                                   , l_just_intonation_ratios
                                   , l_just_intonation_type
                                     ));
 
-    g_music_keys.push_back(MusicKey("Pythagorean Tuning"
-                                  , TemparamentType::Pythagorean
+    g_music_temperaments.push_back(MusicTemperament("Pythagorean Tuning"
+                                  , TemperamentType::Pythagorean
                                   , NoteOffsetType::Ratio
                                   , l_pythagorean_ratio
                                   , l_twelve_note_type
                                     ));
 
-    g_music_keys.push_back(MusicKey("Meantone Temperament"
-                                  , TemparamentType::Meantone
+    g_music_temperaments.push_back(MusicTemperament("Meantone Temperament"
+                                  , TemperamentType::Meantone
                                   , NoteOffsetType::Cents
                                   , l_meantone_temperament_scale
                                   , l_twelve_note_type
                                     ));
 }
 
-std::vector<MusicKey> MusicKey::g_music_keys;
+std::vector<MusicTemperament> MusicTemperament::g_music_temperaments;
 
 const std::string g_music_key_name[NUM_MUSIC_KEYS] =
         {"A             ",

--- a/general/music_temperament.h
+++ b/general/music_temperament.h
@@ -1,5 +1,5 @@
 /***************************************************************************
-                          useful.h  -  Generic useful functions
+                          music_temperament.h
                              -------------------
     begin                : 2002
     copyright            : (C) 2002-2005 by Philip McLeod
@@ -14,19 +14,19 @@
 
    Please read LICENSE.txt for details.
  ***************************************************************************/
-#ifndef TARTINI_MUSIC_KEY_H
-#define TARTINI_MUSIC_KEY_H
+#ifndef TARTINI_MUSIC_TEMPERAMENT_H
+#define TARTINI_MUSIC_TEMPERAMENT_H
 
 #include <vector>
 
 /**
    This defines the notes relative to the root for 1 octave of the scale
 */
-class MusicKey
+class MusicTemperament
 {
   public:
 
-    enum class TemparamentType
+    enum class TemperamentType
     { Even
     , Just
     , Pythagorean
@@ -39,16 +39,16 @@ class MusicKey
     , Ratio     // e.g. [1.0, 5.0/4, 4.0/3, 3.0/2]
     };
 
-    MusicKey(const std::string & p_name
-           , TemparamentType p_temparament_type
+    MusicTemperament(const std::string & p_name
+           , TemperamentType p_temparament_type
            , NoteOffsetType p_note_offset_type
            , const std::vector<double> & p_note_offsets
            , const std::vector<int> & p_note_types
             );
-    ~MusicKey();
+    ~MusicTemperament();
 
     inline const std::string & name()const;
-    inline TemparamentType temparament_type()const;
+    inline TemperamentType temparament_type()const;
     inline int size() const;
     inline double noteOffset(int p_j) const;
     inline int noteType(int p_j) const;
@@ -57,27 +57,27 @@ class MusicKey
     double nearestNoteDistance(const double & p_x)const;
     
     static void init();
-    static inline const std::vector<MusicKey> & getKeys();
+    static inline const std::vector<MusicTemperament> & getTemperaments();
 
   private:
 
     std::string m_name;
-    TemparamentType m_temparament_type;
+    TemperamentType m_temparament_type;
     /**
      * ordered midi values of the notes in 1 octave
      */
     std::vector<double> m_note_offsets;
     std::vector<int> m_note_types;
 
-    static std::vector<MusicKey> g_music_keys;
+    static std::vector<MusicTemperament> g_music_temperaments;
 };
 
-#include "music_key.hpp"
+#include "music_temperament.hpp"
 
 #define NUM_MUSIC_KEYS 12
 extern const std::string g_music_key_name[NUM_MUSIC_KEYS];
 extern int g_music_key_root[NUM_MUSIC_KEYS];
 
 
-#endif //TARTINI_MUSIC_KEY_H
+#endif //TARTINI_MUSIC_TEMPERAMENT_H
 // EOF

--- a/general/music_temperament.hpp
+++ b/general/music_temperament.hpp
@@ -1,5 +1,5 @@
 /***************************************************************************
-                          useful.h  -  Generic useful functions
+                          music_temperament.hpp
                              -------------------
     begin                : 2002
     copyright            : (C) 2002-2005 by Philip McLeod
@@ -15,29 +15,29 @@
    Please read LICENSE.txt for details.
  ***************************************************************************/
 
-#ifndef TARTINI_MUSIC_KEY_HPP
-#define TARTINI_MUSIC_KEY_HPP
+#ifndef TARTINI_MUSIC_TEMPERAMENT_HPP
+#define TARTINI_MUSIC_TEMPERAMENT_HPP
 
 //------------------------------------------------------------------------------
-const std::string & MusicKey::name()const
+const std::string & MusicTemperament::name()const
 {
     return m_name;
 }
 
 //------------------------------------------------------------------------------
-MusicKey::TemparamentType MusicKey::temparament_type()const
+MusicTemperament::TemperamentType MusicTemperament::temparament_type()const
 {
     return m_temparament_type;
 }
 
 //------------------------------------------------------------------------------
-int MusicKey::size() const
+int MusicTemperament::size() const
 {
     return m_note_offsets.size();
 }
 
 //------------------------------------------------------------------------------
-double MusicKey::noteOffset(int p_j) const
+double MusicTemperament::noteOffset(int p_j) const
 {
 #ifdef MYDEBUG
     return m_note_offsets.at(p_j);
@@ -47,7 +47,7 @@ double MusicKey::noteOffset(int p_j) const
 }
 
 //------------------------------------------------------------------------------
-int MusicKey::noteType(int p_j) const
+int MusicTemperament::noteType(int p_j) const
 {
 #ifdef MYDEBUG
     return m_note_types.at(p_j);
@@ -57,10 +57,10 @@ int MusicKey::noteType(int p_j) const
 }
 
 //------------------------------------------------------------------------------
-const std::vector<MusicKey> & MusicKey::getKeys()
+const std::vector<MusicTemperament> & MusicTemperament::getTemperaments()
 {
-    return g_music_keys;
+    return g_music_temperaments;
 }
 
-#endif //TARTINI_MUSIC_KEY_HPP
+#endif //TARTINI_MUSIC_TEMPERAMENT_HPP
 // EOF

--- a/general/musicnotes.cpp
+++ b/general/musicnotes.cpp
@@ -17,7 +17,7 @@
 #include "musicnotes.h"
 #include "myassert.h"
 #include "music_scale.h"
-#include "music_key.h"
+#include "music_temperament.h"
 #include <QObject>
 
 std::string music_notes::m_note_names[12];
@@ -59,7 +59,7 @@ std::string music_notes::m_note_names[12];
 void initMusicStuff()
 {
     music_notes::init_note_names();
-    MusicKey::init();
+    MusicTemperament::init();
     MusicScale::init();
 }
 

--- a/general/musicnotes.cpp
+++ b/general/musicnotes.cpp
@@ -60,18 +60,7 @@ void initMusicStuff()
 {
     music_notes::init_note_names();
     MusicKey::init();
-
-    int l_all_note_scale[12] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
-    int l_major_scale[7]                   = {0, 2, 4, 5, 7, 9, 11 };
-    int l_natural_minor_scale[7]           = {0, 2, 3, 5, 7, 8, 10 };
-    int l_harmonic_minor_scale[7]          = {0, 2, 3, 5, 7, 8, 11 };
-    int l_ascending_melodic_minor_scale[7] = {0, 2, 3, 5, 7, 9, 11 };
-    g_music_scales.resize(5);
-    g_music_scales[MusicScale::Chromatic].addScale("All Notes", l_all_note_scale, 12, 0);
-    g_music_scales[MusicScale::Major].addScale("Major", l_major_scale, 7, 0);
-    g_music_scales[MusicScale::NaturalMinor].addScale("Minor (Natural)", l_natural_minor_scale, 7, 0);
-    g_music_scales[MusicScale::HarmonicMinor].addScale("Minor (Harmonic)", l_harmonic_minor_scale, 7, 0);
-    g_music_scales[MusicScale::MelodicMinor].addScale("Minor (Ascending Melodic)", l_ascending_melodic_minor_scale, 7, 0);
+    MusicScale::init();
 }
 
 /**

--- a/general/musicnotes.cpp
+++ b/general/musicnotes.cpp
@@ -89,16 +89,16 @@ void
 music_notes::init_note_names()
 {
     m_note_names[0] = QObject::tr("C").toStdString();
-    m_note_names[1] = QObject::tr("C#").toStdString();
+    m_note_names[1] = QObject::tr("C♯").toStdString();
     m_note_names[2] = QObject::tr("D").toStdString();
-    m_note_names[3] = QObject::tr("D#").toStdString();
+    m_note_names[3] = QObject::tr("D♯").toStdString();
     m_note_names[4] = QObject::tr("E").toStdString();
     m_note_names[5] = QObject::tr("F").toStdString();
-    m_note_names[6] = QObject::tr("F#").toStdString();
+    m_note_names[6] = QObject::tr("F♯").toStdString();
     m_note_names[7] = QObject::tr("G").toStdString();
-    m_note_names[8] = QObject::tr("G#").toStdString();
+    m_note_names[8] = QObject::tr("G♯").toStdString();
     m_note_names[9] = QObject::tr("A").toStdString();
-    m_note_names[10] = QObject::tr("A#").toStdString();
+    m_note_names[10] = QObject::tr("A♯").toStdString();
     m_note_names[11] = QObject::tr("B").toStdString();
 }
 

--- a/global/gdata.cpp
+++ b/global/gdata.cpp
@@ -135,7 +135,7 @@ GData::GData()
 , m_saving_mode(SavingModes::ALWAYS_ASK)
 , m_vibrato_sine_style(false)
 , m_music_key(3) // C
-, m_music_key_type(0) //ALL_NOTES
+, m_music_key_type(MusicScale::ScaleType::Chromatic) //ALL_NOTES
 , m_tempered_type(0) //EVEN_TEMPERED
 , m_mouse_wheel_zooms(false)
 , m_freq_A(440)
@@ -968,26 +968,10 @@ void GData::setTemperedType(int p_type)
 {
     if(m_tempered_type != p_type)
     {
-        if(m_tempered_type == 0 && p_type > 0)
+        // If the current key type is not compatible with the new tempered type, then set the key type to Chromatic.
+        if(!MusicScale::getScale(m_music_key_type).isCompatibleWithTemparament(static_cast<MusicKey::TemparamentType>(p_type)))
         {
-            //remove out the minors
-            if(m_music_key_type >= 2)
-            {
-                setMusicKeyType(0);
-            }
-            for(int l_j = g_music_scales.size() - 1; l_j >= 2; l_j--)
-            {
-                g_main_window->remove_key_type(l_j);
-            }
-        }
-        else if(m_tempered_type > 0 && p_type == 0)
-        {
-            QStringList l_string_list;
-            for(unsigned int l_j = 2; l_j < g_music_scales.size(); l_j++)
-            {
-                l_string_list << g_music_scales[l_j].name().c_str();
-            }
-            g_main_window->add_key_types(l_string_list);
+            setMusicKeyType(MusicScale::ScaleType::Chromatic);
         }
         m_tempered_type = p_type; emit temperedTypeChanged(p_type);
     }

--- a/global/gdata.cpp
+++ b/global/gdata.cpp
@@ -136,7 +136,7 @@ GData::GData()
 , m_vibrato_sine_style(false)
 , m_music_key(3) // C
 , m_music_key_type(MusicScale::ScaleType::Chromatic) //ALL_NOTES
-, m_tempered_type(0) //EVEN_TEMPERED
+, m_music_temperament(0) //EVEN_TEMPERED
 , m_mouse_wheel_zooms(false)
 , m_freq_A(440)
 , m_semitone_offset(0.0)
@@ -964,16 +964,16 @@ void GData::doFastChunkUpdate()
 }
 
 //------------------------------------------------------------------------------
-void GData::setTemperedType(int p_type)
+void GData::setMusicTemperament(int p_music_temperament)
 {
-    if(m_tempered_type != p_type)
+    if(m_music_temperament != p_music_temperament)
     {
         // If the current key type is not compatible with the new tempered type, then set the key type to Chromatic.
-        if(!MusicScale::getScale(m_music_key_type).isCompatibleWithTemparament(static_cast<MusicKey::TemparamentType>(p_type)))
+        if(!MusicScale::getScale(m_music_key_type).isCompatibleWithTemparament(static_cast<MusicTemperament::TemperamentType>(p_music_temperament)))
         {
-            setMusicKeyType(MusicScale::ScaleType::Chromatic);
+            setMusicScale(MusicScale::ScaleType::Chromatic);
         }
-        m_tempered_type = p_type; emit temperedTypeChanged(p_type);
+        m_music_temperament = p_music_temperament; emit musicTemperamentChanged(p_music_temperament);
     }
 }
 

--- a/global/gdata.h
+++ b/global/gdata.h
@@ -44,6 +44,7 @@
 #include "useful.h"
 #include "view.h"
 #include "analysisdata.h"
+#include "music_scale.h"
 
 #ifndef WINDOWS
 //for multi-threaded profiling
@@ -276,7 +277,7 @@ class GData : public QObject
   inline void set_rms_ceiling(const double &);
 
   inline int musicKey()const;
-  inline int musicKeyType()const;
+  inline MusicScale::ScaleType musicKeyType()const;
   inline int temperedType()const;
   inline const double & freqA()const;
   inline const double & semitoneOffset()const;
@@ -309,6 +310,7 @@ public slots:
 
   inline void setMusicKey(int p_key);
   inline void setMusicKeyType(int p_type);
+  inline void setMusicKeyType(MusicScale::ScaleType p_type);
   void setTemperedType(int p_type);
   void setFreqA(double p_x);
   inline void setFreqA(int p_x);
@@ -416,7 +418,7 @@ public slots:
   t_saving_modes m_saving_mode;
   bool m_vibrato_sine_style;
   int m_music_key;
-  int m_music_key_type;
+  MusicScale::ScaleType m_music_key_type;
   int m_tempered_type;
   bool m_mouse_wheel_zooms;
   double m_freq_A;

--- a/global/gdata.h
+++ b/global/gdata.h
@@ -277,8 +277,8 @@ class GData : public QObject
   inline void set_rms_ceiling(const double &);
 
   inline int musicKey()const;
-  inline MusicScale::ScaleType musicKeyType()const;
-  inline int temperedType()const;
+  inline MusicScale::ScaleType musicScale()const;
+  inline int musicTemperament()const;
   inline const double & freqA()const;
   inline const double & semitoneOffset()const;
 
@@ -294,8 +294,8 @@ signals:
   void onChunkUpdate();
 
   void musicKeyChanged(int p_key);
-  void musicKeyTypeChanged(int p_type);
-  void temperedTypeChanged(int p_type);
+  void musicScaleChanged(int p_type);
+  void musicTemperamentChanged(int p_music_temperament);
 
 public slots:
 
@@ -309,9 +309,9 @@ public slots:
   void setPitchContourMode(int p_pitch_contour_mode);
 
   inline void setMusicKey(int p_key);
-  inline void setMusicKeyType(int p_type);
-  inline void setMusicKeyType(MusicScale::ScaleType p_type);
-  void setTemperedType(int p_type);
+  inline void setMusicScale(int p_type);
+  inline void setMusicScale(MusicScale::ScaleType p_type);
+  void setMusicTemperament(int p_music_temperament);
   void setFreqA(double p_x);
   inline void setFreqA(int p_x);
 
@@ -419,7 +419,7 @@ public slots:
   bool m_vibrato_sine_style;
   int m_music_key;
   MusicScale::ScaleType m_music_key_type;
-  int m_tempered_type;
+  int m_music_temperament;
   bool m_mouse_wheel_zooms;
   double m_freq_A;
   double m_semitone_offset;

--- a/global/gdata.hpp
+++ b/global/gdata.hpp
@@ -522,7 +522,7 @@ int GData::musicKey()const
 }
 
 //------------------------------------------------------------------------------
-int GData::musicKeyType()const
+MusicScale::ScaleType GData::musicKeyType()const
 {
     return m_music_key_type;
 }
@@ -558,10 +558,16 @@ void GData::setMusicKey(int p_key)
 //------------------------------------------------------------------------------
 void GData::setMusicKeyType(int p_type)
 {
+    setMusicKeyType(static_cast<MusicScale::ScaleType>(p_type));
+}
+
+//------------------------------------------------------------------------------
+void GData::setMusicKeyType(MusicScale::ScaleType p_type)
+{
     if(m_music_key_type != p_type)
     {
         m_music_key_type = p_type;
-        emit musicKeyTypeChanged(p_type);
+        emit musicKeyTypeChanged(static_cast<int>(p_type));
     }
 }
 

--- a/global/gdata.hpp
+++ b/global/gdata.hpp
@@ -522,15 +522,15 @@ int GData::musicKey()const
 }
 
 //------------------------------------------------------------------------------
-MusicScale::ScaleType GData::musicKeyType()const
+MusicScale::ScaleType GData::musicScale()const
 {
     return m_music_key_type;
 }
 
 //------------------------------------------------------------------------------
-int GData::temperedType()const
+int GData::musicTemperament()const
 {
-    return m_tempered_type;
+    return m_music_temperament;
 }
 
 //------------------------------------------------------------------------------
@@ -556,18 +556,18 @@ void GData::setMusicKey(int p_key)
 }
 
 //------------------------------------------------------------------------------
-void GData::setMusicKeyType(int p_type)
+void GData::setMusicScale(int p_type)
 {
-    setMusicKeyType(static_cast<MusicScale::ScaleType>(p_type));
+    setMusicScale(static_cast<MusicScale::ScaleType>(p_type));
 }
 
 //------------------------------------------------------------------------------
-void GData::setMusicKeyType(MusicScale::ScaleType p_type)
+void GData::setMusicScale(MusicScale::ScaleType p_type)
 {
     if(m_music_key_type != p_type)
     {
         m_music_key_type = p_type;
-        emit musicKeyTypeChanged(static_cast<int>(p_type));
+        emit musicScaleChanged(static_cast<int>(p_type));
     }
 }
 

--- a/pitch.pro
+++ b/pitch.pro
@@ -96,10 +96,10 @@ HEADERS += \
   general/fast_smooth.hpp \
   general/large_vector.h \
   general/large_vector.hpp \
-  general/music_key.h \
-  general/music_key.hpp \
   general/music_scale.h \
   general/music_scale.hpp \
+  general/music_temperament.h \
+  general/music_temperament.hpp \
   general/musicnotes.h \
   general/musicnotes.hpp \
   general/myalgo.h \
@@ -227,8 +227,8 @@ SOURCES += \
    general/bspline.cpp \
    general/equalloudness.cpp \
    general/fast_smooth.cpp \
-   general/music_key.cpp \
    general/music_scale.cpp \
+   general/music_temperament.cpp \
    general/musicnotes.cpp \
    general/myalgo.cpp \
    general/myglfonts.cpp \

--- a/widgets/freq/freqwidgetGL.cpp
+++ b/widgets/freq/freqwidgetGL.cpp
@@ -200,7 +200,7 @@ void FreqWidgetGL::drawReferenceLinesGL( const double & /* p_left_time*/
 #endif // QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
 
     const MusicKey &l_music_key = MusicKey::getKeys()[GData::getUniqueInstance().temperedType()];
-    const MusicScale &l_music_scale = g_music_scales[GData::getUniqueInstance().musicKeyType()];
+    const MusicScale &l_music_scale = MusicScale::getScale(GData::getUniqueInstance().musicKeyType());
 
     int l_key_root = cycle(g_music_key_root[GData::getUniqueInstance().musicKey()] + l_music_scale.semitoneOffset(), 12);
     int l_view_bottom_note = static_cast<int>(p_view_bottom) - l_key_root;
@@ -234,7 +234,7 @@ void FreqWidgetGL::drawReferenceLinesGL( const double & /* p_left_time*/
                     glColor4ub(0, 0, 0, 128);
                     mygl_line(l_font_width, l_line_Y, width() - 1, l_line_Y);
                 }
-                else if((GData::getUniqueInstance().musicKeyType() == MusicScale::Chromatic) && !g_music_scales[MusicScale::Major].hasSemitone(l_music_key.noteType(l_j)))
+                else if(l_music_scale.isChromaticScale() && !MusicScale::isMajorScaleNote(l_music_key.noteType(l_j)))
                 {
                     glColor4ub(25, 125, 170, 128);
                     glEnable(GL_LINE_STIPPLE);

--- a/widgets/freq/freqwidgetGL.cpp
+++ b/widgets/freq/freqwidgetGL.cpp
@@ -107,9 +107,9 @@ void FreqWidgetGL::drawReferenceLines( QPaintDevice & p_paint_device
     QFontMetrics l_font_metric = p_painter.fontMetrics();
     int l_font_height_space = l_font_metric.height() / 4;
 #if (QT_VERSION >= QT_VERSION_CHECK(5, 11, 0))
-    int l_font_width = l_font_metric.horizontalAdvance("C#0") + 3;
+    int l_font_width = l_font_metric.horizontalAdvance("C♯0") + 3;
 #else // QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
-    int l_font_width = l_font_metric.width("C#0") + 3;
+    int l_font_width = l_font_metric.width("C♯0") + 3;
 #endif // QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
 
     //number of pixels to jump between each line
@@ -194,9 +194,9 @@ void FreqWidgetGL::drawReferenceLinesGL( const double & /* p_left_time*/
     QFontMetrics l_font_metric = fontMetrics();
     int l_font_height_space = l_font_metric.height() / 4;
 #if (QT_VERSION >= QT_VERSION_CHECK(5, 11, 0))
-    int l_font_width = l_font_metric.horizontalAdvance("C#0") + 3;
+    int l_font_width = l_font_metric.horizontalAdvance("C♯0") + 3;
 #else // QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
-    int l_font_width = l_font_metric.width("C#0") + 3;
+    int l_font_width = l_font_metric.width("C♯0") + 3;
 #endif // QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
 
     const MusicKey &l_music_key = MusicKey::getKeys()[GData::getUniqueInstance().temperedType()];

--- a/widgets/freq/freqwidgetGL.cpp
+++ b/widgets/freq/freqwidgetGL.cpp
@@ -42,7 +42,7 @@
 #include "array1d.h"
 #include "musicnotes.h"
 #include "music_scale.h"
-#include "music_key.h"
+#include "music_temperament.h"
 
 #include <sstream>
 #include <QtGlobal>
@@ -199,8 +199,8 @@ void FreqWidgetGL::drawReferenceLinesGL( const double & /* p_left_time*/
     int l_font_width = l_font_metric.width("C♯0") + 3;
 #endif // QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
 
-    const MusicKey &l_music_key = MusicKey::getKeys()[GData::getUniqueInstance().temperedType()];
-    const MusicScale &l_music_scale = MusicScale::getScale(GData::getUniqueInstance().musicKeyType());
+    const MusicTemperament &l_music_temperament = MusicTemperament::getTemperaments()[GData::getUniqueInstance().musicTemperament()];
+    const MusicScale &l_music_scale = MusicScale::getScale(GData::getUniqueInstance().musicScale());
 
     int l_key_root = cycle(g_music_key_root[GData::getUniqueInstance().musicKey()] + l_music_scale.semitoneOffset(), 12);
     int l_view_bottom_note = static_cast<int>(p_view_bottom) - l_key_root;
@@ -221,12 +221,12 @@ void FreqWidgetGL::drawReferenceLinesGL( const double & /* p_left_time*/
     for(int l_octave = l_root_octave; l_octave < l_top_octave; ++l_octave)
     {
         l_cur_root = double(l_octave * 12 + l_root_offset);
-        for(int l_j = 0; l_j < l_music_key.size(); l_j++)
+        for(int l_j = 0; l_j < l_music_temperament.size(); l_j++)
         {
-            if(l_music_scale.hasSemitone(l_music_key.noteType(l_j)))
+            if(l_music_scale.hasSemitone(l_music_temperament.noteType(l_j)))
             {
                 //draw it
-                l_cur_pitch = l_cur_root + l_music_key.noteOffset(l_j);
+                l_cur_pitch = l_cur_root + l_music_temperament.noteOffset(l_j);
                 l_line_Y = double(height()) - myround((l_cur_pitch - p_view_bottom) / p_zoom_Y);
                 if(l_j == 0)
                 {
@@ -234,7 +234,7 @@ void FreqWidgetGL::drawReferenceLinesGL( const double & /* p_left_time*/
                     glColor4ub(0, 0, 0, 128);
                     mygl_line(l_font_width, l_line_Y, width() - 1, l_line_Y);
                 }
-                else if(l_music_scale.isChromaticScale() && !MusicScale::isMajorScaleNote(l_music_key.noteType(l_j)))
+                else if(l_music_scale.isChromaticScale() && !MusicScale::isMajorScaleNote(l_music_temperament.noteType(l_j)))
                 {
                     glColor4ub(25, 125, 170, 128);
                     glEnable(GL_LINE_STIPPLE);
@@ -263,12 +263,12 @@ void FreqWidgetGL::drawReferenceLinesGL( const double & /* p_left_time*/
     for(int l_octave = l_root_octave; l_octave < l_top_octave; ++l_octave)
     {
         l_cur_root = double(l_octave * 12 + l_root_offset);
-        for(int l_j = 0; l_j < l_music_key.size(); l_j++)
+        for(int l_j = 0; l_j < l_music_temperament.size(); l_j++)
         {
-            if(l_music_scale.hasSemitone(l_music_key.noteType(l_j)))
+            if(l_music_scale.hasSemitone(l_music_temperament.noteType(l_j)))
             {
                 //draw it
-                l_cur_pitch = l_cur_root + l_music_key.noteOffset(l_j);
+                l_cur_pitch = l_cur_root + l_music_temperament.noteOffset(l_j);
                 l_line_Y = double(height()) - myround((l_cur_pitch - p_view_bottom) / p_zoom_Y);
                 l_name_index = toInt(l_cur_pitch);
                 glColor3ub(0, 0, 0);

--- a/widgets/mainwindow/mainwindow.cpp
+++ b/widgets/mainwindow/mainwindow.cpp
@@ -460,13 +460,8 @@ MainWindow::MainWindow()
 
     m_key_type_combo_box = new QComboBox(l_key_tool_bar);
     m_key_type_combo_box->setWindowTitle(tr("Scale type"));
-    l_string_list.clear();
-    for(unsigned int l_j = 0; l_j < g_music_scales.size(); l_j++)
-    {
-        l_string_list << g_music_scales[l_j].name().c_str();
-    }
-    m_key_type_combo_box->addItems(l_string_list);
-    m_key_type_combo_box->setCurrentIndex(GData::getUniqueInstance().musicKeyType());
+    updateKeyTypes(GData::getUniqueInstance().temperedType());
+    m_key_type_combo_box->setCurrentIndex(static_cast<int>(GData::getUniqueInstance().musicKeyType()));
     l_key_tool_bar->addWidget(m_key_type_combo_box);
     connect(m_key_type_combo_box, SIGNAL(activated(int)), &GData::getUniqueInstance(), SLOT(setMusicKeyType(int)));
     connect(&GData::getUniqueInstance(), SIGNAL(musicKeyTypeChanged(int)), m_key_type_combo_box, SLOT(setCurrentIndex(int)));
@@ -483,6 +478,7 @@ MainWindow::MainWindow()
     l_tempered_combo_box->setCurrentIndex(GData::getUniqueInstance().temperedType());
     l_key_tool_bar->addWidget(l_tempered_combo_box);
     connect(l_tempered_combo_box, SIGNAL(activated(int)), &GData::getUniqueInstance(), SLOT(setTemperedType(int)));
+    connect(&GData::getUniqueInstance(), SIGNAL(temperedTypeChanged(int)), this, SLOT(updateKeyTypes(int)));
     connect(&GData::getUniqueInstance(), SIGNAL(temperedTypeChanged(int)), l_tempered_combo_box, SLOT(setCurrentIndex(int)));
     connect(&GData::getUniqueInstance(), SIGNAL(temperedTypeChanged(int)), &(GData::getUniqueInstance().getView()), SLOT(doUpdate()));
 
@@ -1392,17 +1388,22 @@ MainWindow::get_view_data(unsigned int p_index)
 
 //------------------------------------------------------------------------------
 void
-MainWindow::remove_key_type(int p_index)
+MainWindow::updateKeyTypes(int p_tempered_type)
 {
-    assert(p_index < m_key_type_combo_box->count());
-    m_key_type_combo_box->removeItem(p_index);
-}
-
-//------------------------------------------------------------------------------
-void
-MainWindow::add_key_types(const QStringList & p_list)
-{
-    m_key_type_combo_box->addItems(p_list);
+    // Update the list of key types based on the tempered type
+    QStringList l_string_list;
+    for(const MusicScale & l_music_scale : MusicScale::getScales())
+    {
+        //remove out the minors
+        if(l_music_scale.isCompatibleWithTemparament(static_cast<MusicKey::TemparamentType>(p_tempered_type)))
+        {
+            l_string_list << l_music_scale.name().c_str();
+        }
+    }
+    QString l_current_text = m_key_type_combo_box->currentText();
+    m_key_type_combo_box->clear();
+    m_key_type_combo_box->addItems(l_string_list);
+    m_key_type_combo_box->setCurrentText(l_current_text);
 }
 
 // EOF

--- a/widgets/mainwindow/mainwindow.cpp
+++ b/widgets/mainwindow/mainwindow.cpp
@@ -58,7 +58,7 @@
 #include "myscrollbar.h"
 #include "mylabel.h"
 #include "music_scale.h"
-#include "music_key.h"
+#include "music_temperament.h"
 #include "tartinidialog.h"
 #include "gpldialog.h"
 
@@ -460,27 +460,27 @@ MainWindow::MainWindow()
 
     m_key_type_combo_box = new QComboBox(l_key_tool_bar);
     m_key_type_combo_box->setWindowTitle(tr("Scale type"));
-    updateKeyTypes(GData::getUniqueInstance().temperedType());
-    m_key_type_combo_box->setCurrentIndex(static_cast<int>(GData::getUniqueInstance().musicKeyType()));
+    updateKeyTypes(GData::getUniqueInstance().musicTemperament());
+    m_key_type_combo_box->setCurrentIndex(static_cast<int>(GData::getUniqueInstance().musicScale()));
     l_key_tool_bar->addWidget(m_key_type_combo_box);
-    connect(m_key_type_combo_box, SIGNAL(activated(int)), &GData::getUniqueInstance(), SLOT(setMusicKeyType(int)));
-    connect(&GData::getUniqueInstance(), SIGNAL(musicKeyTypeChanged(int)), m_key_type_combo_box, SLOT(setCurrentIndex(int)));
-    connect(&GData::getUniqueInstance(), SIGNAL(musicKeyTypeChanged(int)), &(GData::getUniqueInstance().getView()), SLOT(doUpdate()));
+    connect(m_key_type_combo_box, SIGNAL(activated(int)), &GData::getUniqueInstance(), SLOT(setMusicScale(int)));
+    connect(&GData::getUniqueInstance(), SIGNAL(musicScaleChanged(int)), m_key_type_combo_box, SLOT(setCurrentIndex(int)));
+    connect(&GData::getUniqueInstance(), SIGNAL(musicScaleChanged(int)), &(GData::getUniqueInstance().getView()), SLOT(doUpdate()));
 
     QComboBox * l_tempered_combo_box = new QComboBox(l_key_tool_bar);
     l_tempered_combo_box->setWindowTitle(tr("Tempered type"));
     l_string_list.clear();
-    for(const MusicKey & l_music_key : MusicKey::getKeys())
+    for(const MusicTemperament & l_music_temperament : MusicTemperament::getTemperaments())
     {
-        l_string_list << l_music_key.name().c_str();
+        l_string_list << l_music_temperament.name().c_str();
     }
     l_tempered_combo_box->addItems(l_string_list);
-    l_tempered_combo_box->setCurrentIndex(GData::getUniqueInstance().temperedType());
+    l_tempered_combo_box->setCurrentIndex(GData::getUniqueInstance().musicTemperament());
     l_key_tool_bar->addWidget(l_tempered_combo_box);
-    connect(l_tempered_combo_box, SIGNAL(activated(int)), &GData::getUniqueInstance(), SLOT(setTemperedType(int)));
-    connect(&GData::getUniqueInstance(), SIGNAL(temperedTypeChanged(int)), this, SLOT(updateKeyTypes(int)));
-    connect(&GData::getUniqueInstance(), SIGNAL(temperedTypeChanged(int)), l_tempered_combo_box, SLOT(setCurrentIndex(int)));
-    connect(&GData::getUniqueInstance(), SIGNAL(temperedTypeChanged(int)), &(GData::getUniqueInstance().getView()), SLOT(doUpdate()));
+    connect(l_tempered_combo_box, SIGNAL(activated(int)), &GData::getUniqueInstance(), SLOT(setMusicTemperament(int)));
+    connect(&GData::getUniqueInstance(), SIGNAL(musicTemperamentChanged(int)), this, SLOT(updateKeyTypes(int)));
+    connect(&GData::getUniqueInstance(), SIGNAL(musicTemperamentChanged(int)), l_tempered_combo_box, SLOT(setCurrentIndex(int)));
+    connect(&GData::getUniqueInstance(), SIGNAL(musicTemperamentChanged(int)), &(GData::getUniqueInstance().getView()), SLOT(doUpdate()));
 
     QToolBar * l_freq_A_tool_bar = new QToolBar(tr("Frequency Offset Toolbar"), this);
     l_freq_A_tool_bar->setWhatsThis(tr("The frequency of an even-tempered 'A' used for reference lines in the Pitch Contour View. Default 440 Hz."
@@ -1395,7 +1395,7 @@ MainWindow::updateKeyTypes(int p_tempered_type)
     for(const MusicScale & l_music_scale : MusicScale::getScales())
     {
         //remove out the minors
-        if(l_music_scale.isCompatibleWithTemparament(static_cast<MusicKey::TemparamentType>(p_tempered_type)))
+        if(l_music_scale.isCompatibleWithTemparament(static_cast<MusicTemperament::TemperamentType>(p_tempered_type)))
         {
             l_string_list << l_music_scale.name().c_str();
         }

--- a/widgets/mainwindow/mainwindow.h
+++ b/widgets/mainwindow/mainwindow.h
@@ -72,8 +72,6 @@ class MainWindow : public QMainWindow
 
     void keyPressEvent(QKeyEvent * p_event);
     void message(QString p_string, int p_msec);
-    void remove_key_type(int p_index);
-    void add_key_types(const QStringList & p_list);
 
   protected:
     bool event(QEvent * p_event);
@@ -97,6 +95,8 @@ class MainWindow : public QMainWindow
     void windowMenuAboutToShow();
     void windowMenuActivated();
     void newViewAboutToShow();
+
+    void updateKeyTypes(int p_tempered_type);
 
     /**
      * Opens a view based on a viewId (which should be #defined).

--- a/widgets/score/scorewidget.cpp
+++ b/widgets/score/scorewidget.cpp
@@ -47,9 +47,9 @@ ScoreWidget::ScoreWidget(QWidget *p_parent)
     m_pitch_offset = 0; //-12; //display 1 octave down
     m_font = QFont(tr("AnyStyle"), m_font_height);
 #if (QT_VERSION >= QT_VERSION_CHECK(5, 11, 0))
-    m_font_width = QFontMetrics(m_font).horizontalAdvance('#');
+    m_font_width = QFontMetrics(m_font).horizontalAdvance("♯");
 #else // QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
-    m_font_width = QFontMetrics(m_font).width('#');
+    m_font_width = QFontMetrics(m_font).width("♯");
 #endif // QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
     //half a page look ahead
     m_look_ahead = 0.5;
@@ -219,7 +219,7 @@ void ScoreWidget::drawNoteAtPitch( int p_x
         l_y_offset = toInt(m_scale_Y * static_cast<double>(l_y_Steps) * 0.5);
         if(isBlackNote(p_pitch))
         {
-            get_painter().drawText(p_x - l_accidental_offset_X - m_font_width, p_y - l_y_offset + m_font_height / 2, "b");
+            get_painter().drawText(p_x - l_accidental_offset_X - m_font_width, p_y - l_y_offset + m_font_height / 2, "♭");
         }
     }
     else
@@ -228,7 +228,7 @@ void ScoreWidget::drawNoteAtPitch( int p_x
         l_y_offset = toInt(m_scale_Y * static_cast<double>(l_y_Steps) * 0.5);
         if(isBlackNote(p_pitch))
         {
-            get_painter().drawText(p_x - l_accidental_offset_X - m_font_width, p_y - l_y_offset + m_font_height / 2, "#");
+            get_painter().drawText(p_x - l_accidental_offset_X - m_font_width, p_y - l_y_offset + m_font_height / 2, "♯");
         }
     }
 

--- a/widgets/tuner/tunerview.cpp
+++ b/widgets/tuner/tunerview.cpp
@@ -75,7 +75,7 @@ TunerView::TunerView(int p_view_iD_
     m_leds.push_back(new LEDIndicator(this, "F"));
     m_leds.push_back(new LEDIndicator(this, "G"));
 
-    m_leds.push_back(new LEDIndicator(this, "#"));
+    m_leds.push_back(new LEDIndicator(this, "♯"));
 
     // Add the leds for note names into the positions (1, 0) to (1, 6)
     for(int l_n = 0; l_n < 7; l_n++)


### PR DESCRIPTION
- In "C Major, Even Tempered":
    - the key is "C"
    - the scale is "Major"
    - the temperament is "Even Tempered"

- Left class `MusicScale` as is
- Renamed class `MusicKey` to `MusicTemperament`

- In `GData`:
    - Left `musicKey` as is
    - Renamed `musicKeyType` to `musicScale`
    - Renamed `temperedType` to `musicTemperament`

OK, now I think I'll be able to keep it straight!