### PR TITLE
Display octave numbers as subscripts

### DIFF
--- a/general/useful.cpp
+++ b/general/useful.cpp
@@ -420,4 +420,32 @@ int nextPowerOf2(int p_x)
     return l_y;
 }
 
+//------------------------------------------------------------------------------
+std::string toSubscriptString(int p_number)
+{
+    std::string l_string;
+
+    for (char l_digit : std::to_string(p_number))
+    {
+        switch(l_digit)
+        {
+            // Convert characters to corresponding Unicode subscript characters.
+            case '0': l_string += "\u2080"; break;
+            case '1': l_string += "\u2081"; break;
+            case '2': l_string += "\u2082"; break;
+            case '3': l_string += "\u2083"; break;
+            case '4': l_string += "\u2084"; break;
+            case '5': l_string += "\u2085"; break;
+            case '6': l_string += "\u2086"; break;
+            case '7': l_string += "\u2087"; break;
+            case '8': l_string += "\u2088"; break;
+            case '9': l_string += "\u2089"; break;
+            case '+': l_string += "\u208A"; break;
+            case '-': l_string += "\u208B"; break;
+            default: myassert(false); break;
+        }
+    }
+    return l_string;
+}
+
 //EOF

--- a/general/useful.h
+++ b/general/useful.h
@@ -365,6 +365,8 @@ bool moveFile( const std::string & p_src
 */
 int nextPowerOf2(int p_x);
 
+std::string toSubscriptString(int p_number);
+
 #include <algorithm>
 
 /**

--- a/widgets/freq/freqwidgetGL.cpp
+++ b/widgets/freq/freqwidgetGL.cpp
@@ -144,7 +144,7 @@ void FreqWidgetGL::drawReferenceLines( QPaintDevice & p_paint_device
         if(!isBlackNote(l_name_index))
         {
             p_painter.setPen(Qt::black);
-            l_note_label = QString::fromStdString(music_notes::noteName(l_name_index) + std::to_string(noteOctave(l_name_index)));
+            l_note_label = QString::fromStdString(music_notes::noteName(l_name_index) + toSubscriptString(noteOctave(l_name_index)));
             p_painter.drawText(2, l_line_Y + l_font_height_space, l_note_label);
             if(noteValue(l_name_index) == 0)
             {
@@ -272,9 +272,7 @@ void FreqWidgetGL::drawReferenceLinesGL( const double & /* p_left_time*/
                 l_line_Y = double(height()) - myround((l_cur_pitch - p_view_bottom) / p_zoom_Y);
                 l_name_index = toInt(l_cur_pitch);
                 glColor3ub(0, 0, 0);
-                std::stringstream l_stream ;
-                l_stream << music_notes::noteName(l_name_index) << noteOctave(l_name_index);
-                l_note_label = QString(l_stream.str().c_str());
+                l_note_label = QString::fromStdString(music_notes::noteName(l_name_index) + toSubscriptString(noteOctave(l_name_index)));
                 renderText(2, toInt(l_line_Y) + l_font_height_space, l_note_label);
             }
             if(p_zoom_Y > 0.1)


### PR DESCRIPTION
Use subscripts for octave numbers in SPN (Scientific pitch notation)

- Add new helper `toSubscriptString(int p_number)` that converts a number to the corresponding Unicode subscript characters
- Convert octave numbers to subscripts in `FreqWidgetGL::drawReferenceLines` and `FreqWidgetGL::drawReferenceLinesGL`