### PR TITLE
Pitch compass features

### DIFF
--- a/widgets/pitchcompass/pitchcompassdrawwidget.cpp
+++ b/widgets/pitchcompass/pitchcompassdrawwidget.cpp
@@ -32,7 +32,7 @@
 //------------------------------------------------------------------------------
 PitchCompassDrawWidget::PitchCompassDrawWidget( QWidget *p_parent
                                               , const std::string & p_name
-                                              , int p_mode
+                                              , PitchCompassView::CompassMode p_mode
                                               )
 : QWidget(p_parent)
 , m_compass(new QwtCompass(this))
@@ -49,7 +49,7 @@ PitchCompassDrawWidget::PitchCompassDrawWidget( QWidget *p_parent
     QwtCompassScaleDraw *l_scale_draw = new QwtCompassScaleDraw();
 #endif // QWT_VERSION >= 0x060000
 
-    if(p_mode == 0)
+    if(m_mode == PitchCompassView::CompassMode::Mode0)
     {
         m_compass->setMode(QwtCompass::RotateNeedle);
 #if QWT_VERSION >= 0x060000
@@ -60,12 +60,12 @@ PitchCompassDrawWidget::PitchCompassDrawWidget( QWidget *p_parent
         m_compass->setScale(36, 5, 0);
 #endif // QWT_VERSION >= 0x060000
     }
-    else if(p_mode == 1)
+    else if(m_mode == PitchCompassView::CompassMode::Mode1)
     {
         m_compass->setMode(QwtCompass::RotateScale);
         m_compass->setScale(360, 0);
     }
-    else if(p_mode == 2)
+    else if(m_mode == PitchCompassView::CompassMode::Mode2)
     {
         m_compass->setMode(QwtCompass::RotateNeedle);
         QMap< double, QString > l_notes;
@@ -142,7 +142,7 @@ void PitchCompassDrawWidget::updateCompass(double p_time)
         double l_pitch = l_data->getPitch();
         unsigned int l_interval = 90;
 
-        if(m_mode == 0)
+        if(m_mode == PitchCompassView::CompassMode::Mode0)
         {
             QMap< double, QString > l_notes;
             double l_zero_val = myround(l_pitch);
@@ -169,7 +169,7 @@ void PitchCompassDrawWidget::updateCompass(double p_time)
             m_compass->setLabelMap(l_notes);
 #endif // QWT_VERSION >= 0x060000
         }
-        else if(m_mode == 1)
+        else if(m_mode == PitchCompassView::CompassMode::Mode1)
         {
             QMap< double, QString > l_notes;
             double l_close_pitch = myround(l_pitch);
@@ -196,10 +196,14 @@ void PitchCompassDrawWidget::updateCompass(double p_time)
             m_compass->setLabelMap(l_notes);
 #endif // QWT_VERSION >= 0x060000
         }
-        else
+        else if (m_mode == PitchCompassView::CompassMode::Mode2)
         {
             // mode == 2
             m_compass->setValue(noteValue(l_pitch) + l_pitch - toInt(l_pitch));
+        }
+        else
+        {
+            myassert(false);
         }
 
         m_compass->setValid(true);
@@ -215,7 +219,7 @@ void PitchCompassDrawWidget::blank(bool p_force)
 {
     if(p_force || ++m_blank_count >= 10)
     {
-        if(m_mode != 2)
+        if(m_mode != PitchCompassView::CompassMode::Mode2)
         {
             QMap< double, QString > l_notes;
 #if QWT_VERSION >= 0x060000

--- a/widgets/pitchcompass/pitchcompassdrawwidget.cpp
+++ b/widgets/pitchcompass/pitchcompassdrawwidget.cpp
@@ -125,6 +125,30 @@ void PitchCompassDrawWidget::resizeEvent(QResizeEvent *)
 }
 
 //------------------------------------------------------------------------------
+void PitchCompassDrawWidget::setCompassScale()
+{
+    // Placeholder
+}
+
+//------------------------------------------------------------------------------
+void PitchCompassDrawWidget::updateMusicKey(int)
+{
+    if (m_mode == PitchCompassView::CompassMode::Mode2)
+    {
+        setCompassScale();
+    }
+}
+
+//------------------------------------------------------------------------------
+void PitchCompassDrawWidget::updateMusicScale(int)
+{
+    if (m_mode == PitchCompassView::CompassMode::Mode2)
+    {
+        setCompassScale();
+    }
+}
+
+//------------------------------------------------------------------------------
 void PitchCompassDrawWidget::updateCompass(double p_time)
 {
     const AnalysisData *l_data = nullptr;

--- a/widgets/pitchcompass/pitchcompassdrawwidget.cpp
+++ b/widgets/pitchcompass/pitchcompassdrawwidget.cpp
@@ -36,7 +36,7 @@ PitchCompassDrawWidget::PitchCompassDrawWidget( QWidget *p_parent
                                               )
 : QWidget(p_parent)
 , m_compass(new QwtCompass(this))
-, m_blank_count(9)
+, m_blank_count(0)
 , m_mode(p_mode)
 {
     setObjectName(QString::fromStdString(p_name));
@@ -107,7 +107,7 @@ PitchCompassDrawWidget::PitchCompassDrawWidget( QWidget *p_parent
     m_compass->setValue(0.0);
 
     // Force a blank update
-    blank();
+    blank(true);
 
     m_compass->setReadOnly(true);
     m_compass->show();
@@ -211,9 +211,9 @@ void PitchCompassDrawWidget::updateCompass(double p_time)
 }
 
 //------------------------------------------------------------------------------
-void PitchCompassDrawWidget::blank()
+void PitchCompassDrawWidget::blank(bool p_force)
 {
-    if(++m_blank_count % 10 == 0)
+    if(p_force || ++m_blank_count >= 10)
     {
         if(m_mode != 2)
         {

--- a/widgets/pitchcompass/pitchcompassdrawwidget.cpp
+++ b/widgets/pitchcompass/pitchcompassdrawwidget.cpp
@@ -117,6 +117,7 @@ PitchCompassDrawWidget::PitchCompassDrawWidget( QWidget *p_parent
 //------------------------------------------------------------------------------
 PitchCompassDrawWidget::~PitchCompassDrawWidget()
 {
+    delete m_compass;
 }
 
 //------------------------------------------------------------------------------

--- a/widgets/pitchcompass/pitchcompassdrawwidget.cpp
+++ b/widgets/pitchcompass/pitchcompassdrawwidget.cpp
@@ -94,6 +94,7 @@ void PitchCompassDrawWidget::setCompassScale()
     else if(m_mode == PitchCompassView::CompassMode::Mode2)
     {
         int l_music_key = GData::getUniqueInstance().musicKey();
+        const MusicScale &l_music_scale = MusicScale::getScale(GData::getUniqueInstance().musicScale());
 
         m_compass->setMode(QwtCompass::RotateNeedle);
         QMap< double, QString > l_notes;
@@ -103,8 +104,32 @@ void PitchCompassDrawWidget::setCompassScale()
         m_compass->setSingleSteps(30);
         for(int l_index = 0; l_index < 12; l_index++)
         {
-            std::string label = music_notes::noteName(cycle(l_index + g_music_key_roots[l_music_key], 12));
-            l_notes[l_index] = QString::fromStdString(label);
+            if(l_music_scale.hasSemitone(l_index))
+            {
+                std::string label = music_notes::noteName(cycle(l_index + g_music_key_roots[l_music_key], 12));
+                
+                // Minimize how much the compass resizes due to differences in the lengths of the labels.
+                // Make all of the labels two characters wide.  Don't use regular spaces, since the compass will trim them.
+                if (label.length() < 2)
+                {
+                    if (l_index > 0 && l_index < 6)
+                    {
+                        // Right side of the compass -- pad on the right
+                        label += "\u2002";  // Unicode "En Space"
+                    }
+                    else if (l_index > 6)
+                    {
+                        // Left side of the compass -- pad on the left
+                        label = "\u2002" + label;  // Unicode "En Space"
+                    }
+                }
+                l_notes[l_index] = QString::fromStdString(label);
+            }
+            else
+            {
+                // Pad with two spaces
+                l_notes[l_index] = "\u2002\u2002";  // Unicode "En Space"
+            }
         }
         l_scale_draw->setLabelMap(l_notes);
 #else

--- a/widgets/pitchcompass/pitchcompassdrawwidget.cpp
+++ b/widgets/pitchcompass/pitchcompassdrawwidget.cpp
@@ -127,15 +127,14 @@ void PitchCompassDrawWidget::resizeEvent(QResizeEvent *)
 //------------------------------------------------------------------------------
 void PitchCompassDrawWidget::updateCompass(double p_time)
 {
+    const AnalysisData *l_data = nullptr;
     Channel *l_active_channel = GData::getUniqueInstance().getActiveChannel();
-    if(l_active_channel == nullptr)
+    
+    if(l_active_channel)
     {
-        blank();
-        return;
+        l_data = l_active_channel->dataAtTime(p_time);
     }
-
-    const AnalysisData *l_data = l_active_channel->dataAtTime(p_time);
-
+    
     if(l_data && l_data->getCorrelation() >= 0.9)
     {
         double l_pitch = l_data->getPitch();

--- a/widgets/pitchcompass/pitchcompassdrawwidget.cpp
+++ b/widgets/pitchcompass/pitchcompassdrawwidget.cpp
@@ -35,12 +35,13 @@ PitchCompassDrawWidget::PitchCompassDrawWidget( QWidget *p_parent
                                               , int p_mode
                                               )
 : QWidget(p_parent)
+, m_compass(new QwtCompass(this))
+, m_blank_count(9)
+, m_mode(p_mode)
 {
     setObjectName(QString::fromStdString(p_name));
     setAttribute(Qt::WA_DeleteOnClose);
-    this->m_mode = p_mode;
 
-    m_compass = new QwtCompass(this);
     m_compass->setLineWidth(4);
     m_compass->setFrameShadow(QwtCompass::Sunken);
 
@@ -106,7 +107,6 @@ PitchCompassDrawWidget::PitchCompassDrawWidget( QWidget *p_parent
     m_compass->setValue(0.0);
 
     // Force a blank update
-    m_blank_count = 9;
     blank();
 
     m_compass->setReadOnly(true);

--- a/widgets/pitchcompass/pitchcompassdrawwidget.cpp
+++ b/widgets/pitchcompass/pitchcompassdrawwidget.cpp
@@ -27,8 +27,6 @@
 #include <qwt_dial_needle.h>
 #include <QResizeEvent>
 
-#include "assert.h"
-
 //------------------------------------------------------------------------------
 PitchCompassDrawWidget::PitchCompassDrawWidget( QWidget *p_parent
                                               , const std::string & p_name

--- a/widgets/pitchcompass/pitchcompassdrawwidget.cpp
+++ b/widgets/pitchcompass/pitchcompassdrawwidget.cpp
@@ -43,6 +43,34 @@ PitchCompassDrawWidget::PitchCompassDrawWidget( QWidget *p_parent
     m_compass->setLineWidth(4);
     m_compass->setFrameShadow(QwtCompass::Sunken);
 
+    setCompassScale();
+
+    m_compass->setNeedle(new QwtCompassMagnetNeedle(QwtCompassMagnetNeedle::ThinStyle));
+    m_compass->setValue(0.0);
+
+    // Force a blank update
+    blank(true);
+
+    m_compass->setReadOnly(true);
+    m_compass->show();
+
+}
+
+//------------------------------------------------------------------------------
+PitchCompassDrawWidget::~PitchCompassDrawWidget()
+{
+    delete m_compass;
+}
+
+//------------------------------------------------------------------------------
+void PitchCompassDrawWidget::resizeEvent(QResizeEvent *)
+{
+    m_compass->resize(size());
+}
+
+//------------------------------------------------------------------------------
+void PitchCompassDrawWidget::setCompassScale()
+{
 #if QWT_VERSION >= 0x060000
     QwtCompassScaleDraw *l_scale_draw = new QwtCompassScaleDraw();
 #endif // QWT_VERSION >= 0x060000
@@ -52,8 +80,8 @@ PitchCompassDrawWidget::PitchCompassDrawWidget( QWidget *p_parent
         m_compass->setMode(QwtCompass::RotateNeedle);
 #if QWT_VERSION >= 0x060000
         m_compass->setScale(36, 5);
-	    // Stepping is now defined by qwt_abstract_slider
-	    m_compass->setSingleSteps(0);
+        // Stepping is now defined by qwt_abstract_slider
+        m_compass->setSingleSteps(0);
 #else
         m_compass->setScale(36, 5, 0);
 #endif // QWT_VERSION >= 0x060000
@@ -100,34 +128,6 @@ PitchCompassDrawWidget::PitchCompassDrawWidget( QWidget *p_parent
 #else
     m_compass->setScaleTicks(1, 1, 3);
 #endif // QWT_VERSION >= 0x060000
-
-    m_compass->setNeedle(new QwtCompassMagnetNeedle(QwtCompassMagnetNeedle::ThinStyle));
-    m_compass->setValue(0.0);
-
-    // Force a blank update
-    blank(true);
-
-    m_compass->setReadOnly(true);
-    m_compass->show();
-
-}
-
-//------------------------------------------------------------------------------
-PitchCompassDrawWidget::~PitchCompassDrawWidget()
-{
-    delete m_compass;
-}
-
-//------------------------------------------------------------------------------
-void PitchCompassDrawWidget::resizeEvent(QResizeEvent *)
-{
-    m_compass->resize(size());
-}
-
-//------------------------------------------------------------------------------
-void PitchCompassDrawWidget::setCompassScale()
-{
-    // Placeholder
 }
 
 //------------------------------------------------------------------------------

--- a/widgets/pitchcompass/pitchcompassdrawwidget.h
+++ b/widgets/pitchcompass/pitchcompassdrawwidget.h
@@ -12,7 +12,6 @@
 #ifndef PITCHCOMPASSDRAWWIDGET_H
 #define PITCHCOMPASSDRAWWIDGET_H
 
-#include "drawwidget.h"
 #include <QResizeEvent>
 
 class QwtCompass;

--- a/widgets/pitchcompass/pitchcompassdrawwidget.h
+++ b/widgets/pitchcompass/pitchcompassdrawwidget.h
@@ -13,6 +13,7 @@
 #define PITCHCOMPASSDRAWWIDGET_H
 
 #include <QResizeEvent>
+#include "pitchcompassview.h"
 
 class QwtCompass;
 
@@ -24,7 +25,7 @@ class PitchCompassDrawWidget: public QWidget
   public:
     PitchCompassDrawWidget( QWidget * p_parent
                           , const std::string & p_name = ""
-                          , int p_mode = 0
+                          , PitchCompassView::CompassMode p_mode = PitchCompassView::CompassMode::Mode2
                           );
     virtual ~PitchCompassDrawWidget();
 
@@ -42,7 +43,7 @@ class PitchCompassDrawWidget: public QWidget
 
     int m_blank_count;
 
-    int m_mode;
+    PitchCompassView::CompassMode m_mode;
 };
 #endif // PITCHCOMPASSDRAWWIDGET_H
 // EOF

--- a/widgets/pitchcompass/pitchcompassdrawwidget.h
+++ b/widgets/pitchcompass/pitchcompassdrawwidget.h
@@ -36,7 +36,7 @@ class PitchCompassDrawWidget: public QWidget
 
   private:
 
-    void blank();
+    void blank(bool p_force = false);
 
     QwtCompass * m_compass;
 

--- a/widgets/pitchcompass/pitchcompassdrawwidget.h
+++ b/widgets/pitchcompass/pitchcompassdrawwidget.h
@@ -33,10 +33,13 @@ class PitchCompassDrawWidget: public QWidget
 
   public slots:
 
+    void updateMusicKey(int p_music_key);
+    void updateMusicScale(int p_music_scale);
     void updateCompass(double p_time);
 
   private:
 
+    void setCompassScale();
     void blank(bool p_force = false);
 
     QwtCompass * m_compass;

--- a/widgets/pitchcompass/pitchcompassdrawwidget.h
+++ b/widgets/pitchcompass/pitchcompassdrawwidget.h
@@ -41,8 +41,6 @@ class PitchCompassDrawWidget: public QWidget
 
     QwtCompass * m_compass;
 
-    bool m_move_needle;
-
     int m_blank_count;
 
     int m_mode;

--- a/widgets/pitchcompass/pitchcompassview.cpp
+++ b/widgets/pitchcompass/pitchcompassview.cpp
@@ -28,6 +28,9 @@ PitchCompassView::PitchCompassView( int p_view_id
 , m_pitch_compass_draw_widget(new PitchCompassDrawWidget(this, "compass", p_mode))
 {
     connect(&(GData::getUniqueInstance().getView()), SIGNAL(onFastUpdate(double)), m_pitch_compass_draw_widget, SLOT(updateCompass(double)));
+    connect(&(GData::getUniqueInstance()), SIGNAL(musicKeyChanged(int)), m_pitch_compass_draw_widget, SLOT(updateMusicKey(int)));
+    connect(&(GData::getUniqueInstance()), SIGNAL(musicScaleChanged(int)), m_pitch_compass_draw_widget, SLOT(updateMusicScale(int)));
+
     m_pitch_compass_draw_widget->show();
 }
 

--- a/widgets/pitchcompass/pitchcompassview.cpp
+++ b/widgets/pitchcompass/pitchcompassview.cpp
@@ -22,7 +22,7 @@
 //------------------------------------------------------------------------------
 PitchCompassView::PitchCompassView( int p_view_id
                                   , QWidget *p_parent
-                                  , int p_mode
+                                  , CompassMode p_mode
                                   )
 : ViewWidget(p_view_id, p_parent)
 , m_pitch_compass_draw_widget(new PitchCompassDrawWidget(this, "compass", p_mode))
@@ -43,7 +43,7 @@ void PitchCompassView::resizeEvent(QResizeEvent *)
 }
 
 //------------------------------------------------------------------------------
-void PitchCompassView::changeMode(int p_mode)
+void PitchCompassView::changeMode(CompassMode p_mode)
 {
     delete m_pitch_compass_draw_widget;
     m_pitch_compass_draw_widget = new PitchCompassDrawWidget(this, "compass", p_mode);

--- a/widgets/pitchcompass/pitchcompassview.cpp
+++ b/widgets/pitchcompass/pitchcompassview.cpp
@@ -34,6 +34,7 @@ PitchCompassView::PitchCompassView( int p_view_id
 //------------------------------------------------------------------------------
 PitchCompassView::~PitchCompassView()
 {
+    delete m_pitch_compass_draw_widget;
 }
 
 //------------------------------------------------------------------------------

--- a/widgets/pitchcompass/pitchcompassview.cpp
+++ b/widgets/pitchcompass/pitchcompassview.cpp
@@ -25,8 +25,8 @@ PitchCompassView::PitchCompassView( int p_view_id
                                   , int p_mode
                                   )
 : ViewWidget(p_view_id, p_parent)
+, m_pitch_compass_draw_widget(new PitchCompassDrawWidget(this, "compass", p_mode))
 {
-    m_pitch_compass_draw_widget = new PitchCompassDrawWidget(this, "compass", p_mode);
     connect(&(GData::getUniqueInstance().getView()), SIGNAL(onFastUpdate(double)), m_pitch_compass_draw_widget, SLOT(updateCompass(double)));
     m_pitch_compass_draw_widget->show();
 }

--- a/widgets/pitchcompass/pitchcompassview.h
+++ b/widgets/pitchcompass/pitchcompassview.h
@@ -29,9 +29,15 @@ class PitchCompassView: public ViewWidget
 
   public:
 
+    enum class CompassMode
+    { Mode0
+    , Mode1
+    , Mode2
+    };
+    
     PitchCompassView( int p_view_id
                     , QWidget * p_parent = nullptr
-                    , int p_mode = 2
+                    , CompassMode p_mode = CompassMode::Mode2
                     );
     virtual ~PitchCompassView();
 
@@ -40,7 +46,7 @@ class PitchCompassView: public ViewWidget
     void resizeEvent(QResizeEvent *);
 
  private:
-    void changeMode(int p_mode);
+    void changeMode(CompassMode p_mode);
 
     PitchCompassDrawWidget * m_pitch_compass_draw_widget;
 


### PR DESCRIPTION
- Rotate the compass so the root of the selected key is at the top
- Show or hide compass labels based on the selected scale
- As a test, open `examle.wav`, set the key to "G" and the scale to "Major"
    - When you play the file, the compass only points to the named notes