### PR TITLE
Make the Chromatic Tuner use tempered pitches

### DIFF
--- a/music/music_temperament.cpp
+++ b/music/music_temperament.cpp
@@ -26,6 +26,7 @@ MusicTemperament::MusicTemperament(const std::string & p_name
                    )
 : m_name(p_name)
 , m_temparament_type(p_temparament_type)
+, m_size(p_note_offsets.size())
 , m_note_offsets(p_note_offsets)
 , m_note_types(p_note_types)
 {
@@ -51,6 +52,10 @@ MusicTemperament::MusicTemperament(const std::string & p_name
             }
             break;
     }
+    
+    // Add entries for the octave so that binary search works for notes at the top of the scale.
+    m_note_offsets.push_back(12.0);
+    m_note_types.push_back(12);
 }
 
 //------------------------------------------------------------------------------
@@ -65,15 +70,21 @@ int MusicTemperament::nearestNoteIndex(const double & p_x)const
 }
 
 //------------------------------------------------------------------------------
-double MusicTemperament::nearestNote(const double & p_x)const
+double MusicTemperament::nearestNoteOffset(const double & p_x)const
 {
-    return *binary_search_closest(m_note_offsets.begin(), m_note_offsets.end(), p_x);
+    return noteOffset(nearestNoteIndex(p_x));
 }
 
 //------------------------------------------------------------------------------
 double MusicTemperament::nearestNoteDistance(const double & p_x)const
 {
-    return fabs(*binary_search_closest(m_note_offsets.begin(), m_note_offsets.end(), p_x) - p_x);
+    return fabs(nearestNoteOffset(p_x) - p_x);
+}
+
+//------------------------------------------------------------------------------
+int MusicTemperament::nearestNoteType(const double & p_x)const
+{
+    return noteType(nearestNoteIndex(p_x));
 }
 
 //------------------------------------------------------------------------------

--- a/music/music_temperament.h
+++ b/music/music_temperament.h
@@ -51,12 +51,31 @@ class MusicTemperament
 
     inline const std::string & name()const;
     inline TemperamentType temparament_type()const;
+    inline bool isEvenTempered() const;
     inline int size() const;
+    /**
+       The pitch offset (0.0 - 12.0) of the temparament entry.  Includes an extra entry for the octave.
+       @param p_j 0..size()
+    */
     inline double noteOffset(int p_j) const;
+    /**
+       The nominal note (0 - 12) of the temparament entry.  Includes an extra entry for the octave.
+       @param p_j 0..size()
+    */
     inline int noteType(int p_j) const;
+    /**
+       @return The index of the  temparament entry that has the closest pitch offset to the given offset.  Returns size() if the octave is closest.
+    */
     int nearestNoteIndex(const double & p_x)const;
-    double nearestNote(const double & p_x)const;
+    /**
+       @return The pitch offset of the temparament entry that is closest to the given offset.  Returns 12.0 if the octave is closest.
+    */
+    double nearestNoteOffset(const double & p_x)const;
     double nearestNoteDistance(const double & p_x)const;
+    /**
+       @return The nominal note of the temparament entry that is closest to the given offset.  Returns 12 if the octave is closest.
+    */
+    int nearestNoteType(const double & p_x)const;
     
     static void init();
     static inline const std::array<MusicTemperament, 4> & getTemperaments();
@@ -66,6 +85,7 @@ class MusicTemperament
 
     std::string m_name;
     TemperamentType m_temparament_type;
+    int m_size;
     /**
      * ordered midi values of the notes in 1 octave
      */

--- a/music/music_temperament.hpp
+++ b/music/music_temperament.hpp
@@ -31,9 +31,15 @@ MusicTemperament::TemperamentType MusicTemperament::temparament_type()const
 }
 
 //------------------------------------------------------------------------------
+bool MusicTemperament::isEvenTempered() const
+{
+    return m_temparament_type == TemperamentType::Even;
+}
+
+//------------------------------------------------------------------------------
 int MusicTemperament::size() const
 {
-    return m_note_offsets.size();
+    return m_size;
 }
 
 //------------------------------------------------------------------------------

--- a/music/musicnotes.cpp
+++ b/music/musicnotes.cpp
@@ -69,6 +69,94 @@ int noteValue(int p_pitch)
 }
 
 //------------------------------------------------------------------------------
+int music_notes::noteValueInKey(int p_pitch, int p_key)
+{
+    return noteValue(p_pitch - p_key);
+}
+
+//------------------------------------------------------------------------------
+double music_notes::noteOffsetInKey(const double & p_pitch, int p_key)
+{
+    return cycle(p_pitch - (double)p_key, 12.0);
+}
+
+//------------------------------------------------------------------------------
+double music_notes::temperedPitch(int p_nominal_pitch
+                                , int p_music_key
+                                , const MusicTemperament & p_music_temperament
+                                  )
+{
+    if (p_music_temperament.isEvenTempered())
+    {
+        return (double)p_nominal_pitch;
+    }
+    
+    int l_note_in_key = noteValueInKey(p_nominal_pitch, p_music_key);
+    int l_temperament_index = -1;
+    
+    for (int l_i = 0; l_i < p_music_temperament.size(); l_i++)
+    {
+        if (p_music_temperament.noteType(l_i) == l_note_in_key)
+        {
+            l_temperament_index = l_i;
+            break;
+        }
+    }
+    
+    if (l_temperament_index == -1)
+    {
+        // The temperament does not contain the note.
+        return 0;
+    }
+    
+    double l_temperament_pitch = p_music_temperament.noteOffset(l_temperament_index);
+    double l_tempered_pitch = p_nominal_pitch + (l_temperament_pitch - l_note_in_key);
+
+#ifdef DEBUG_PRINTF
+    std::cout << ">>> music_notes::temperedPitch() <<<" << std::endl;
+    std::cout << "  nominal pitch = " << p_nominal_pitch << " (" << noteName(p_nominal_pitch) << ")" << std::endl;
+    std::cout << "  music key = " << p_music_key << " (" << noteName(p_music_key) << ")" << std::endl;
+    std::cout << "  music temperament = " << p_music_temperament.name() << std::endl;
+    std::cout << "  note in key = " << l_note_in_key << std::endl;
+    std::cout << "  tempered offset = " << l_temperament_pitch << std::endl;
+    std::cout << "  tempered pitch = " << l_tempered_pitch << std::endl;
+#endif // DEBUG_PRINTF
+    
+    // Return the even tempered pitch adjusted by the difference in the tempered pitch and the nominal note).
+    return l_tempered_pitch;
+}
+
+//------------------------------------------------------------------------------
+int music_notes::closestNote(const double & p_pitch
+                           , int p_music_key
+                           , const MusicTemperament & p_music_temperament
+                             )
+{
+    if (p_music_temperament.isEvenTempered())
+    {
+        return toInt(p_pitch);
+    }
+    
+    double l_offset_in_key = noteOffsetInKey(p_pitch, p_music_key);
+    int l_closest_offset = p_music_temperament.nearestNoteType(l_offset_in_key);
+    int l_root_of_key = toInt(p_pitch - l_offset_in_key);
+    double l_closest_note = l_root_of_key + l_closest_offset;
+
+#ifdef DEBUG_PRINTF
+    std::cout << ">>> music_notes::closestNote() <<<" << std::endl;
+    std::cout << "  input pitch = " << p_pitch << std::endl;
+    std::cout << "  music key = " << p_music_key << " (" << noteName(p_music_key) << ")" << std::endl;
+    std::cout << "  music temperament = " << p_music_temperament.name() << std::endl;
+    std::cout << "  offset in key = " << l_offset_in_key << std::endl;
+    std::cout << "  closest key offset = " << l_closest_offset << std::endl;
+    std::cout << "  root of key = " << l_root_of_key << std::endl;
+    std::cout << "  closest note = " << l_closest_note << " (" << noteName(l_closest_note) << ")" << std::endl;
+#endif // DEBUG_PRINTF
+
+    return l_closest_note;
+}
+
+//------------------------------------------------------------------------------
 bool isBlackNote(int p_pitch)
 {
     switch(cycle(p_pitch, 12))

--- a/music/musicnotes.h
+++ b/music/musicnotes.h
@@ -21,6 +21,9 @@
 #include "myassert.h"
 #include <string>
 
+class MusicScale;
+class MusicTemperament;
+
 class music_notes
 {
   public:
@@ -30,6 +33,25 @@ class music_notes
 
     static inline
     const std::string & noteName(const double & p_pitch);
+    static int noteValueInKey(int p_pitch, int p_key);
+    static double noteOffsetInKey(const double & p_pitch, int p_key);
+
+    /**
+       @return The tempered value of a nominal pitch, given the key, and temperament.  Returns 0 if the temperament does not include this note.
+    */
+    static double temperedPitch(int p_nominal_pitch
+                              , int p_music_key
+                              , const MusicTemperament & p_music_temperament
+                                );
+
+    /**
+       Finds the closest tempered pitch to a pitch, given the key, and temperament.
+       @return The nominal pitch of the closest tempered pitch.
+    */
+    static int closestNote(const double & p_pitch
+                         , int p_music_key
+                         , const MusicTemperament & p_music_temperament
+                           );
 
     static
     void init_note_names();

--- a/widgets/tuner/tunerview.cpp
+++ b/widgets/tuner/tunerview.cpp
@@ -93,6 +93,8 @@ TunerView::TunerView(int p_view_iD_
     l_layout->setRowStretch( 2, 0 );
 
     connect(&GData::getUniqueInstance(), SIGNAL(onChunkUpdate()), this, SLOT(doUpdate()));
+    connect(&GData::getUniqueInstance(), SIGNAL(musicKeyChanged(int)), this, SLOT(doUpdate()));
+    connect(&GData::getUniqueInstance(), SIGNAL(musicTemperamentChanged(int)), this, SLOT(doUpdate()));
     connect(m_tuner_widget, SIGNAL(ledSet(int, bool)), this, SLOT(setLed(int, bool)));
 }
 

--- a/widgets/vibrato/vibratotunerwidget.cpp
+++ b/widgets/vibrato/vibratotunerwidget.cpp
@@ -28,7 +28,7 @@ VibratoTunerWidget::VibratoTunerWidget(QWidget *parent)
 : QGLWidget(parent)
 , m_needle_value_to_draw(-999)
 , m_prev_needle_value(-999)
-, m_prev_close_pitch(0)
+, m_prev_close_note(0)
 , m_cur_pitch(0.0)
 , m_cents_label_X(0.0)
 , m_cents_label_Y(0.0)
@@ -228,7 +228,7 @@ void VibratoTunerWidget::resizeGL( int p_width
     // Do forced update on resize
     m_needle_value_to_draw = -999;
     m_prev_needle_value = -999;
-    m_prev_close_pitch = -1;
+    m_prev_close_note = 0;
     doUpdate(m_cur_pitch);
 }
 
@@ -277,7 +277,6 @@ void VibratoTunerWidget::paintGL()
 #endif // TIME_PAINT
 }
 
-#define DEBUG_PRINTF
 //------------------------------------------------------------------------------
 void VibratoTunerWidget::doUpdate(double p_pitch)
 {
@@ -302,7 +301,7 @@ void VibratoTunerWidget::doUpdate(double p_pitch)
     std::cout << "  needle value = " << l_needle_value << std::endl;
 #endif // DEBUG_PRINTF
     
-    if ((fabs(m_prev_needle_value - l_needle_value) < 0.05) && (m_prev_close_pitch == l_close_pitch))
+    if ((fabs(m_prev_needle_value - l_needle_value) < 0.05) && (m_prev_close_note == l_close_note))
     {
         // Pitch hasn't changed (much), no update needed
     }
@@ -314,11 +313,11 @@ void VibratoTunerWidget::doUpdate(double p_pitch)
         glNewList(m_needle, GL_COMPILE);
         glEndList();
 
-        if (l_close_pitch == 0)
+        if (l_close_note == 0)
         {
             // No pitch, don't draw the needle this update
             m_prev_needle_value = -999;
-            m_prev_close_pitch = 0;
+            m_prev_close_note = 0;
             m_needle_value_to_draw = -999;
             resetLeds();
             updateGL();
@@ -336,7 +335,7 @@ void VibratoTunerWidget::doUpdate(double p_pitch)
             }
 
             m_prev_needle_value = l_needle_value;
-            m_prev_close_pitch = l_close_pitch;
+            m_prev_close_note = l_close_note;
 
             m_needle_value_to_draw = l_needle_value;
 

--- a/widgets/vibrato/vibratotunerwidget.cpp
+++ b/widgets/vibrato/vibratotunerwidget.cpp
@@ -283,16 +283,6 @@ void VibratoTunerWidget::doUpdate(double p_pitch)
 {
     m_cur_pitch = p_pitch;
 
-    Channel * l_active_channel = GData::getUniqueInstance().getActiveChannel();
-
-    if (l_active_channel)
-    {
-        AnalysisData * l_data = l_active_channel->dataAtCurrentChunk();
-        if(l_data && l_active_channel->isVisibleNote(l_data->getNoteIndex()) && l_active_channel->isLabelNote(l_data->getNoteIndex()))
-        {
-        }
-    }
-
     // The current musical key and temperament.
     int l_music_key = g_music_key_roots[GData::getUniqueInstance().musicKey()];
     const MusicTemperament &l_music_temperament = MusicTemperament::getTemperament(GData::getUniqueInstance().musicTemperament());

--- a/widgets/vibrato/vibratotunerwidget.h
+++ b/widgets/vibrato/vibratotunerwidget.h
@@ -51,7 +51,7 @@ class VibratoTunerWidget: public QGLWidget
 
     float m_needle_value_to_draw;
     float m_prev_needle_value;
-    int m_prev_close_pitch;
+    int m_prev_close_note;
     double m_cur_pitch;
 
     QFont m_tuner_font;


### PR DESCRIPTION
The tuner now compares the current pitch to the closest pitch in the selected tempered key.
- Improvements to `MusicTemperament`
- Additions to `music_notes` to support finding the nearest tempered pitch
- Changes to `VibratoTunerWidget` to look up the closest tempered note and use that to update the LEDs and the needle