### PR TITLE
Fix for bug in Pitch Compass

### DIFF
--- a/widgets/pitchcompass/pitchcompassdrawwidget.cpp
+++ b/widgets/pitchcompass/pitchcompassdrawwidget.cpp
@@ -255,7 +255,7 @@ void PitchCompassDrawWidget::updateCompass(double p_time)
         else if (m_mode == PitchCompassView::CompassMode::Mode2)
         {
             int l_music_key = GData::getUniqueInstance().musicKey();
-            m_compass->setValue(cycle(noteValue(l_pitch) - g_music_key_roots[l_music_key], 12) + l_pitch - toInt(l_pitch));
+            m_compass->setValue(cycle(l_pitch - (double)g_music_key_roots[l_music_key], 12.0) );
         }
         else
         {


### PR DESCRIPTION
- Use `cycle()` properly in `PitchCompassDrawWidget::updateCompass()` for `Mode2`
    - To reproduce, open `sweep20-200log.wav` and notice that the compass "sticks" as the needle passes from B to C (due to rounding issues)
    - This bug was present even before the recent enhancements to rotate the compass based on the key.