### PR TITLE
Simplify usage of `closestNote()` and `temperedPitch()` with default values

### DIFF
--- a/music/musicnotes.cpp
+++ b/music/musicnotes.cpp
@@ -31,9 +31,9 @@ void initMusicStuff()
 }
 
 //------------------------------------------------------------------------------
-const std::string & music_notes::noteName(int p_pitch)
+const std::string & music_notes::noteName(int p_note)
 {
-    return m_note_names[cycle(p_pitch, 12)];
+    return m_note_names[cycle(p_note, 12)];
 }
 
 //------------------------------------------------------------------------------
@@ -57,41 +57,41 @@ music_notes::init_note_names()
 }
 
 //------------------------------------------------------------------------------
-int noteOctave(int p_pitch)
+int noteOctave(int p_note)
 {
-    return (p_pitch / 12) - 1;
+    return (p_note / 12) - 1;
 }
 
 //------------------------------------------------------------------------------
-int noteValue(int p_pitch)
+int noteValue(int p_note)
 {
-    return cycle(p_pitch, 12);
+    return cycle(p_note, 12);
 }
 
 //------------------------------------------------------------------------------
-int music_notes::noteValueInKey(int p_pitch, int p_key)
+int music_notes::noteValueInKey(int p_note, int p_key)
 {
-    return noteValue(p_pitch - p_key);
+    return noteValue(p_note - p_key);
 }
 
 //------------------------------------------------------------------------------
-double music_notes::noteOffsetInKey(const double & p_pitch, int p_key)
+double music_notes::pitchOffsetInKey(const double & p_pitch, int p_key)
 {
     return cycle(p_pitch - (double)p_key, 12.0);
 }
 
 //------------------------------------------------------------------------------
-double music_notes::temperedPitch(int p_nominal_pitch
+double music_notes::temperedPitch(int p_note
                                 , int p_music_key
                                 , const MusicTemperament & p_music_temperament
                                   )
 {
     if (p_music_temperament.isEvenTempered())
     {
-        return (double)p_nominal_pitch;
+        return (double)p_note;
     }
     
-    int l_note_in_key = noteValueInKey(p_nominal_pitch, p_music_key);
+    int l_note_in_key = noteValueInKey(p_note, p_music_key);
     int l_temperament_index = -1;
     
     for (int l_i = 0; l_i < p_music_temperament.size(); l_i++)
@@ -110,11 +110,11 @@ double music_notes::temperedPitch(int p_nominal_pitch
     }
     
     double l_temperament_pitch = p_music_temperament.noteOffset(l_temperament_index);
-    double l_tempered_pitch = p_nominal_pitch + (l_temperament_pitch - l_note_in_key);
+    double l_tempered_pitch = p_note + (l_temperament_pitch - l_note_in_key);
 
 #ifdef DEBUG_PRINTF
     std::cout << ">>> music_notes::temperedPitch() <<<" << std::endl;
-    std::cout << "  nominal pitch = " << p_nominal_pitch << " (" << noteName(p_nominal_pitch) << ")" << std::endl;
+    std::cout << "  nominal pitch = " << p_note << " (" << noteName(p_note) << ")" << std::endl;
     std::cout << "  music key = " << p_music_key << " (" << noteName(p_music_key) << ")" << std::endl;
     std::cout << "  music temperament = " << p_music_temperament.name() << std::endl;
     std::cout << "  note in key = " << l_note_in_key << std::endl;
@@ -137,7 +137,7 @@ int music_notes::closestNote(const double & p_pitch
         return toInt(p_pitch);
     }
     
-    double l_offset_in_key = noteOffsetInKey(p_pitch, p_music_key);
+    double l_offset_in_key = pitchOffsetInKey(p_pitch, p_music_key);
     int l_closest_offset = p_music_temperament.nearestNoteType(l_offset_in_key);
     int l_root_of_key = toInt(p_pitch - l_offset_in_key);
     double l_closest_note = l_root_of_key + l_closest_offset;
@@ -157,9 +157,9 @@ int music_notes::closestNote(const double & p_pitch
 }
 
 //------------------------------------------------------------------------------
-bool isBlackNote(int p_pitch)
+bool isBlackNote(int p_note)
 {
-    switch(cycle(p_pitch, 12))
+    switch(cycle(p_note, 12))
     {
         case 1:
         case 3:

--- a/music/musicnotes.h
+++ b/music/musicnotes.h
@@ -23,29 +23,52 @@
 #include "gdata.h"
 #include "music_temperament.h"
 
+/**
+ Helper class for musical notes
+ 
+ Terminology:
+ - A "note" is an integer value that represents a musical note, such as C4.  The values are MIDI note numbers, e.g. C4 = 60.
+ - A "pitch" is a floating-point value that represents the pitch of the note, also measured on the MIDI scale.
+ 
+ The mapping between note numbers and pitches depends on the key and temperament.
+ For example, the note G4 (66) in Pythagorean temperament (in the key of C) has a pitch of 66.0196, which is 1.96 cents higher than in even temperament.
+ Only in even temperament do the note numbers correspond to the pitch values.
+ - Use `temperedPitch()` to convert from a note number to the corresponding pitch.
+ - Use `closestNote()` to convert from a pitch to the corresponding note number.
+ 
+ You can pass the key and temperament explicitly or rely on the default values, which use the globally selected key and temperament in `GData`
+ */
 class music_notes
 {
   public:
 
     static
-    const std::string & noteName(int p_pitch);
+    const std::string & noteName(int p_note);
 
-    [[deprecated("Use closestNote() instead")]]
+    /// @deprecated Use closestNote() to convert pitches to notes
+    [[deprecated("Use closestNote() to convert pitches to notes")]]
     static inline const std::string & noteName(const double & p_pitch);
-    static int noteValueInKey(int p_pitch, int p_key);
-    static double noteOffsetInKey(const double & p_pitch, int p_key);
+    static int noteValueInKey(int p_note, int p_key);
+    static double pitchOffsetInKey(const double & p_pitch, int p_key);
 
     /**
-       @return The tempered value of a nominal pitch, given the key, and temperament.  Returns 0 if the temperament does not include this note.
+     The tempered pitch of a note, given the key and temperament
+     @param p_note The note number
+     @param p_music_key The musical key (0..11).  If not specified, defaults to the globally selected key: `GData::musicKey()`
+     @param p_music_temperament The musical temperament.  If not specified, defaults to the globally selected temperament: `GData::musicTemperament()`
+     @return The tempered pitch.  Returns 0 if the temperament does not include the note
     */
-    static double temperedPitch(int p_nominal_pitch
+    static double temperedPitch(int p_note
                               , int p_music_key = g_music_key_roots[GData::getUniqueInstance().musicKey()]
                               , const MusicTemperament & p_music_temperament = MusicTemperament::getTemperament(GData::getUniqueInstance().musicTemperament())
                                 );
 
     /**
-       Finds the closest tempered pitch to a pitch, given the key, and temperament.
-       @return The nominal pitch of the closest tempered pitch.
+     The closest note to a pitch, given the key and temperament
+     @param p_pitch The pitch
+     @param p_music_key The musical key (0..11).  If not specified, defaults to the globally selected key: `GData::musicKey()`
+     @param p_music_temperament The musical temperament.  If not specified, defaults to the globally selected temperament: `GData::musicTemperament()`
+     @return The note associated with the closest pitch in the temperament
     */
     static int closestNote(const double & p_pitch
                          , int p_music_key = g_music_key_roots[GData::getUniqueInstance().musicKey()]
@@ -60,7 +83,7 @@ class music_notes
 };
 
 /**
-   Converts the frequencies freq (in hertz) into their note number on the midi scale
+   Converts the frequencies freq (in hertz) into their pitch on the midi scale
    i.e. the number of semi-tones above C0
    Note: The note's pitch will contain its fractional part
    Reference = http://www.borg.com/~jglatt/tutr/notenum.htm
@@ -72,26 +95,29 @@ inline double freq2pitch(const double & p_freq);
 /**
    Does the opposite of the function above
 */
-inline double pitch2freq(const double & p_note);
+inline double pitch2freq(const double & p_pitch);
 
 /**
-   @param p_pitch The midi note number
+   @param p_note The midi note number
    @return The note octave. Middle C (midi note 60) is defined as octave 4. Making midi note 0 in octave -1
 */
-int noteOctave(int p_pitch);
-[[deprecated("Use closestNote() instead")]]
+int noteOctave(int p_note);
+/// @deprecated Use closestNote() to convert pitches to notes
+[[deprecated("Use closestNote() to convert pitches to notes")]]
 inline int noteOctave(const double & p_pitch);
 
 /**
-   @param p_pitch The midi note number
+   @param p_note The midi note number
    @return The midi note within one octave. Range = 0 to 11. Where 0=C, 1=C# ... 11 = B.
 */
-int noteValue(int p_pitch);
-[[deprecated("Use closestNote() instead")]]
+int noteValue(int p_note);
+/// @deprecated Use closestNote() to convert pitches to notes
+[[deprecated("Use closestNote() to convert pitches to notes")]]
 inline int noteValue(const double & p_pitch);
 
-bool isBlackNote(int p_pitch);
-[[deprecated("Use closestNote() instead")]]
+bool isBlackNote(int p_note);
+/// @deprecated Use closestNote() to convert pitches to notes
+[[deprecated("Use closestNote() to convert pitches to notes")]]
 inline bool isBlackNote(const double & p_pitch);
 
 

--- a/music/musicnotes.h
+++ b/music/musicnotes.h
@@ -30,8 +30,8 @@ class music_notes
     static
     const std::string & noteName(int p_pitch);
 
-    static inline
-    const std::string & noteName(const double & p_pitch);
+    [[deprecated("Use closestNote() instead")]]
+    static inline const std::string & noteName(const double & p_pitch);
     static int noteValueInKey(int p_pitch, int p_key);
     static double noteOffsetInKey(const double & p_pitch, int p_key);
 
@@ -79,6 +79,7 @@ inline double pitch2freq(const double & p_note);
    @return The note octave. Middle C (midi note 60) is defined as octave 4. Making midi note 0 in octave -1
 */
 int noteOctave(int p_pitch);
+[[deprecated("Use closestNote() instead")]]
 inline int noteOctave(const double & p_pitch);
 
 /**
@@ -86,9 +87,11 @@ inline int noteOctave(const double & p_pitch);
    @return The midi note within one octave. Range = 0 to 11. Where 0=C, 1=C# ... 11 = B.
 */
 int noteValue(int p_pitch);
+[[deprecated("Use closestNote() instead")]]
 inline int noteValue(const double & p_pitch);
 
 bool isBlackNote(int p_pitch);
+[[deprecated("Use closestNote() instead")]]
 inline bool isBlackNote(const double & p_pitch);
 
 

--- a/music/musicnotes.h
+++ b/music/musicnotes.h
@@ -20,9 +20,8 @@
 #include "useful.h"
 #include "myassert.h"
 #include <string>
-
-class MusicScale;
-class MusicTemperament;
+#include "gdata.h"
+#include "music_temperament.h"
 
 class music_notes
 {
@@ -40,8 +39,8 @@ class music_notes
        @return The tempered value of a nominal pitch, given the key, and temperament.  Returns 0 if the temperament does not include this note.
     */
     static double temperedPitch(int p_nominal_pitch
-                              , int p_music_key
-                              , const MusicTemperament & p_music_temperament
+                              , int p_music_key = g_music_key_roots[GData::getUniqueInstance().musicKey()]
+                              , const MusicTemperament & p_music_temperament = MusicTemperament::getTemperament(GData::getUniqueInstance().musicTemperament())
                                 );
 
     /**
@@ -49,8 +48,8 @@ class music_notes
        @return The nominal pitch of the closest tempered pitch.
     */
     static int closestNote(const double & p_pitch
-                         , int p_music_key
-                         , const MusicTemperament & p_music_temperament
+                         , int p_music_key = g_music_key_roots[GData::getUniqueInstance().musicKey()]
+                         , const MusicTemperament & p_music_temperament = MusicTemperament::getTemperament(GData::getUniqueInstance().musicTemperament())
                            );
 
     static

--- a/music/musicnotes.hpp
+++ b/music/musicnotes.hpp
@@ -31,9 +31,9 @@ double freq2pitch(const double & p_freq)
 }
 
 //------------------------------------------------------------------------------
-double pitch2freq(const double & p_note)
+double pitch2freq(const double & p_pitch)
 {
-    double l_result = pow10((p_note + 36.3763165622959152488) / 39.8631371386483481);
+    double l_result = pow10((p_pitch + 36.3763165622959152488) / 39.8631371386483481);
     return l_result;
 }
 

--- a/music/musicnotes.hpp
+++ b/music/musicnotes.hpp
@@ -40,25 +40,33 @@ double pitch2freq(const double & p_note)
 //------------------------------------------------------------------------------
 const std::string & music_notes::noteName(const double & p_pitch)
 {
-    return noteName(toInt(p_pitch));
+    // This method is deprecated, but don't remove it.
+    // Otherwise, a call to `noteName(double)` would use implicit conversions to call `noteName(int)`, which would truncate the pitch value.
+    return noteName(closestNote(p_pitch));
 }
 
 //------------------------------------------------------------------------------
 int noteOctave(const double & p_pitch)
 {
-    return noteOctave(toInt(p_pitch));
+    // This function is deprecated, but don't remove it.
+    // Otherwise, a call to `noteOctave(double)` would use implicit conversions to call `noteOctave(int)`, which would truncate the pitch value.
+    return noteOctave(music_notes::closestNote(p_pitch));
 }
 
 //------------------------------------------------------------------------------
 int noteValue(const double & p_pitch)
 {
-    return noteValue(toInt(p_pitch));
+    // This function is deprecated, but don't remove it.
+    // Otherwise, a call to `noteValue(double)` would use implicit conversions to call `noteValue(int)`, which would truncate the pitch value.
+    return noteValue(music_notes::closestNote(p_pitch));
 }
 
 //------------------------------------------------------------------------------
 bool isBlackNote(const double & p_pitch)
 {
-    return isBlackNote(toInt(p_pitch));
+    // This function is deprecated, but don't remove it.
+    // Otherwise, a call to `isBlackNote(double)` would use implicit conversions to call `isBlackNote(int)`, which would truncate the pitch value.
+    return isBlackNote(music_notes::closestNote(p_pitch));
 }
 
 //EOF

--- a/widgets/piano/pianoview.cpp
+++ b/widgets/piano/pianoview.cpp
@@ -56,13 +56,10 @@ void PianoView::changeKey()
         AnalysisData * l_data = l_active_channel->dataAtCurrentChunk();
         if(l_data && l_active_channel->isVisibleChunk(l_data))
         {
-            // The current musical key and temperament.
-            int l_music_key = g_music_key_roots[GData::getUniqueInstance().musicKey()];
-            const MusicTemperament &l_music_temperament = MusicTemperament::getTemperament(GData::getUniqueInstance().musicTemperament());
             float l_pitch = l_data->getPitch();
             
             // The nominal note that has the closest tempered pitch to p_pitch (used to update the LEDs).
-            int l_close_note = music_notes::closestNote(l_pitch, l_music_key, l_music_temperament);
+            int l_close_note = music_notes::closestNote(l_pitch);
             m_piano_widget->setCurrentNote(noteValue(l_close_note), l_data->getCorrelation());
         }
         else

--- a/widgets/vibrato/vibratotunerwidget.cpp
+++ b/widgets/vibrato/vibratotunerwidget.cpp
@@ -282,14 +282,10 @@ void VibratoTunerWidget::doUpdate(double p_pitch)
 {
     m_cur_pitch = p_pitch;
 
-    // The current musical key and temperament.
-    int l_music_key = g_music_key_roots[GData::getUniqueInstance().musicKey()];
-    const MusicTemperament &l_music_temperament = MusicTemperament::getTemperament(GData::getUniqueInstance().musicTemperament());
-    
     // The nominal note that has the closest tempered pitch to p_pitch (used to update the LEDs).
-    int l_close_note = music_notes::closestNote(p_pitch, l_music_key, l_music_temperament);
+    int l_close_note = music_notes::closestNote(p_pitch);
     // The tempered pitch associated with the nominal note value (used for the needle).
-    double l_close_pitch = music_notes::temperedPitch(l_close_note, l_music_key, l_music_temperament);
+    double l_close_pitch = music_notes::temperedPitch(l_close_note);
     float l_needle_value = 100 * (p_pitch - l_close_pitch);
 
 #ifdef DEBUG_PRINTF


### PR DESCRIPTION
- Add default parameter values to `closestNote()` and `temperedPitch()` to simplify usage
    - Uses the current global key and temperament from `GData` if they are not passed explicitly
- Simplify code in `VibratoTunerWidget` and `PianoView` to use new default values
- Prevent automatic rounding of pitches to integer values
    - Update `noteName(double)`, `noteOctave(double)`, `noteValue(double)`, and `isBlackNote(double)` to use `closestNote()` instead of `toInt()`
    - Mark `noteName(double)`, `noteOctave(double)`, `noteValue(double)`, and `isBlackNote(double)` as deprecated
    - They are not used anywhere and it is better to explicitly call `closestNote()` if that is what you intend
    - Don't delete the functions, since then a call to `noteOctave(double)` would use implicit conversions to call `noteOctave(int)`, which would truncate the pitch value
- Clarified distinction between "notes" and "pitches" in `music_notes`
    - Add documentation describing the difference between "note" and "pitch"
    - Renamed parameters from `p_pitch` to `p_note` as appropriate (and vice versa)
    - Renamed `noteOffsetInKey()` to `pitchOffsetInKey()`
    - Added `@deprecated` doc tags in addition to C++14 `[[deprecated]]` attributes
    - Added docstrings for `temperedPitch()` and `closestNote()` that include description of default parameter values