### PR TITLE
Rename `music_notes` class to `MusicNote`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,8 +128,8 @@ set(MY_HEADER_FILES
     general/mygl.h
     general/mygl.hpp
     general/myqt.h
-    music/musicnotes.h
-    music/musicnotes.hpp
+    music/music_note.h
+    music/music_note.hpp
     general/myalgo.h
     include/RingBuffer.h
     music/music_scale.h
@@ -228,7 +228,7 @@ set(MY_SOURCE_FILES
     general/prony.cpp
     general/mymatrix.cpp
     general/myqt.cpp
-    music/musicnotes.cpp
+    music/music_note.cpp
     general/myalgo.cpp
     music/music_scale.cpp
     music/music_temperament.cpp

--- a/general/mytransforms.cpp
+++ b/general/mytransforms.cpp
@@ -902,7 +902,7 @@ void MyTransforms::doChannelDataFFT( Channel * p_channel
         }
         AnalysisData &l_analysis_data = *p_channel->dataAtChunk(p_chunk);
         l_analysis_data.setCepstrumIndex(findNSDFsubMaximum(m_data_time, l_n_div_2, 0.6f));
-        l_analysis_data.setCepstrumPitch(freq2pitch(double(l_analysis_data.getCepstrumIndex()) / p_channel->rate()));
+        l_analysis_data.setCepstrumPitch(MusicNote::freq2pitch(double(l_analysis_data.getCepstrumIndex()) / p_channel->rate()));
     }
 }
 

--- a/general/mytransforms.cpp
+++ b/general/mytransforms.cpp
@@ -24,7 +24,7 @@
 #include "channel.h"
 #include "Filter.h"
 #include "conversions.h"
-#include "musicnotes.h"
+#include "music_note.h"
 
 #include "useful.h"
 #include <algorithm>

--- a/general/useful.cpp
+++ b/general/useful.cpp
@@ -420,32 +420,4 @@ int nextPowerOf2(int p_x)
     return l_y;
 }
 
-//------------------------------------------------------------------------------
-std::string toSubscriptString(int p_number)
-{
-    std::string l_string;
-
-    for (char l_digit : std::to_string(p_number))
-    {
-        switch(l_digit)
-        {
-            // Convert characters to corresponding Unicode subscript characters.
-            case '0': l_string += "\u2080"; break;
-            case '1': l_string += "\u2081"; break;
-            case '2': l_string += "\u2082"; break;
-            case '3': l_string += "\u2083"; break;
-            case '4': l_string += "\u2084"; break;
-            case '5': l_string += "\u2085"; break;
-            case '6': l_string += "\u2086"; break;
-            case '7': l_string += "\u2087"; break;
-            case '8': l_string += "\u2088"; break;
-            case '9': l_string += "\u2089"; break;
-            case '+': l_string += "\u208A"; break;
-            case '-': l_string += "\u208B"; break;
-            default: myassert(false); break;
-        }
-    }
-    return l_string;
-}
-
 //EOF

--- a/general/useful.h
+++ b/general/useful.h
@@ -369,8 +369,6 @@ bool moveFile( const std::string & p_src
 */
 int nextPowerOf2(int p_x);
 
-std::string toSubscriptString(int p_number);
-
 #include <algorithm>
 
 /**

--- a/global/gdata.cpp
+++ b/global/gdata.cpp
@@ -147,7 +147,7 @@ GData::GData()
     m_line_color.push_back(Qt::darkYellow);
     m_line_color.push_back(Qt::darkGray);
 
-    initMusicStuff();
+    MusicNote::initMusicStuff();
 }
 
 //------------------------------------------------------------------------------
@@ -943,7 +943,7 @@ void GData::setMusicTemperament(MusicTemperament::TemperamentType p_music_temper
 void GData::setFreqA(double p_x)
 {
     m_freq_A = p_x;
-    m_semitone_offset = freq2pitch(p_x) - freq2pitch(440.0);
+    m_semitone_offset = MusicNote::freq2pitch(p_x) - MusicNote::freq2pitch(440.0);
     m_settings->setValue("View/freqA", p_x);
 }
 

--- a/global/gdata.cpp
+++ b/global/gdata.cpp
@@ -41,7 +41,7 @@
 #include "tartinisettingsdialog.h"
 #include "savedialog.h"
 #include "conversions.h"
-#include "musicnotes.h"
+#include "music_note.h"
 #include "music_scale.h"
 #include <sstream>
 #include <iomanip>

--- a/music/music_note.cpp
+++ b/music/music_note.cpp
@@ -1,5 +1,5 @@
 /***************************************************************************
-                          musicnotes.cpp
+                          music_note.cpp
                              -------------------
     begin                : 2002
     copyright            : (C) 2002-2005 by Philip McLeod
@@ -14,31 +14,31 @@
    
    Please read LICENSE.txt for details.
  ***************************************************************************/
-#include "musicnotes.h"
+#include "music_note.h"
 #include "myassert.h"
 #include "music_scale.h"
 #include "music_temperament.h"
 #include <QObject>
 
-std::array<std::string, 12> music_notes::m_note_names;
+std::array<std::string, 12> MusicNote::m_note_names;
 
 //------------------------------------------------------------------------------
 void initMusicStuff()
 {
-    music_notes::init_note_names();
+    MusicNote::init_note_names();
     MusicTemperament::init();
     MusicScale::init();
 }
 
 //------------------------------------------------------------------------------
-const std::string & music_notes::noteName(int p_note)
+const std::string & MusicNote::noteName(int p_note)
 {
     return m_note_names[cycle(p_note, 12)];
 }
 
 //------------------------------------------------------------------------------
 void
-music_notes::init_note_names()
+MusicNote::init_note_names()
 {
     m_note_names =
     {{ QObject::tr("C").toStdString()
@@ -69,19 +69,19 @@ int noteValue(int p_note)
 }
 
 //------------------------------------------------------------------------------
-int music_notes::noteValueInKey(int p_note, int p_key)
+int MusicNote::noteValueInKey(int p_note, int p_key)
 {
     return noteValue(p_note - p_key);
 }
 
 //------------------------------------------------------------------------------
-double music_notes::pitchOffsetInKey(const double & p_pitch, int p_key)
+double MusicNote::pitchOffsetInKey(const double & p_pitch, int p_key)
 {
     return cycle(p_pitch - (double)p_key, 12.0);
 }
 
 //------------------------------------------------------------------------------
-double music_notes::temperedPitch(int p_note
+double MusicNote::temperedPitch(int p_note
                                 , int p_music_key
                                 , const MusicTemperament & p_music_temperament
                                   )
@@ -113,7 +113,7 @@ double music_notes::temperedPitch(int p_note
     double l_tempered_pitch = p_note + (l_temperament_pitch - l_note_in_key);
 
 #ifdef DEBUG_PRINTF
-    std::cout << ">>> music_notes::temperedPitch() <<<" << std::endl;
+    std::cout << ">>> MusicNote::temperedPitch() <<<" << std::endl;
     std::cout << "  nominal pitch = " << p_note << " (" << noteName(p_note) << ")" << std::endl;
     std::cout << "  music key = " << p_music_key << " (" << noteName(p_music_key) << ")" << std::endl;
     std::cout << "  music temperament = " << p_music_temperament.name() << std::endl;
@@ -127,7 +127,7 @@ double music_notes::temperedPitch(int p_note
 }
 
 //------------------------------------------------------------------------------
-int music_notes::closestNote(const double & p_pitch
+int MusicNote::closestNote(const double & p_pitch
                            , int p_music_key
                            , const MusicTemperament & p_music_temperament
                              )
@@ -143,7 +143,7 @@ int music_notes::closestNote(const double & p_pitch
     double l_closest_note = l_root_of_key + l_closest_offset;
 
 #ifdef DEBUG_PRINTF
-    std::cout << ">>> music_notes::closestNote() <<<" << std::endl;
+    std::cout << ">>> MusicNote::closestNote() <<<" << std::endl;
     std::cout << "  input pitch = " << p_pitch << std::endl;
     std::cout << "  music key = " << p_music_key << " (" << noteName(p_music_key) << ")" << std::endl;
     std::cout << "  music temperament = " << p_music_temperament.name() << std::endl;

--- a/music/music_note.cpp
+++ b/music/music_note.cpp
@@ -23,9 +23,9 @@
 std::array<std::string, 12> MusicNote::m_note_names;
 
 //------------------------------------------------------------------------------
-void initMusicStuff()
+void MusicNote::initMusicStuff()
 {
-    MusicNote::init_note_names();
+    init_note_names();
     MusicTemperament::init();
     MusicScale::init();
 }
@@ -57,13 +57,13 @@ MusicNote::init_note_names()
 }
 
 //------------------------------------------------------------------------------
-int noteOctave(int p_note)
+int MusicNote::noteOctave(int p_note)
 {
     return (p_note / 12) - 1;
 }
 
 //------------------------------------------------------------------------------
-int noteValue(int p_note)
+int MusicNote::noteValue(int p_note)
 {
     return cycle(p_note, 12);
 }
@@ -113,7 +113,7 @@ double MusicNote::temperedPitch(int p_note
     double l_tempered_pitch = p_note + (l_temperament_pitch - l_note_in_key);
 
 #ifdef DEBUG_PRINTF
-    std::cout << ">>> MusicNote::temperedPitch() <<<" << std::endl;
+    std::cout << ">>> temperedPitch() <<<" << std::endl;
     std::cout << "  nominal pitch = " << p_note << " (" << noteName(p_note) << ")" << std::endl;
     std::cout << "  music key = " << p_music_key << " (" << noteName(p_music_key) << ")" << std::endl;
     std::cout << "  music temperament = " << p_music_temperament.name() << std::endl;
@@ -143,7 +143,7 @@ int MusicNote::closestNote(const double & p_pitch
     double l_closest_note = l_root_of_key + l_closest_offset;
 
 #ifdef DEBUG_PRINTF
-    std::cout << ">>> MusicNote::closestNote() <<<" << std::endl;
+    std::cout << ">>> closestNote() <<<" << std::endl;
     std::cout << "  input pitch = " << p_pitch << std::endl;
     std::cout << "  music key = " << p_music_key << " (" << noteName(p_music_key) << ")" << std::endl;
     std::cout << "  music temperament = " << p_music_temperament.name() << std::endl;
@@ -157,7 +157,7 @@ int MusicNote::closestNote(const double & p_pitch
 }
 
 //------------------------------------------------------------------------------
-bool isBlackNote(int p_note)
+bool MusicNote::isBlackNote(int p_note)
 {
     switch(cycle(p_note, 12))
     {

--- a/music/music_note.cpp
+++ b/music/music_note.cpp
@@ -20,7 +20,7 @@
 #include "music_temperament.h"
 #include <QObject>
 
-std::array<std::string, 12> MusicNote::m_note_names;
+std::array<std::string, 12> MusicNote::m_semitone_names;
 
 //------------------------------------------------------------------------------
 void MusicNote::initMusicStuff()
@@ -31,16 +31,24 @@ void MusicNote::initMusicStuff()
 }
 
 //------------------------------------------------------------------------------
-const std::string & MusicNote::noteName(int p_note)
+std::string MusicNote::noteName(int p_note)
 {
-    return m_note_names[semitoneValue(p_note)];
+    return semitoneName(semitoneValue(p_note)) + octaveName(noteOctave(p_note));
+}
+
+//------------------------------------------------------------------------------
+const std::string & MusicNote::semitoneName(int p_semitone)
+{
+    myassert(p_semitone >= 0 && p_semitone < 12);
+    
+    return m_semitone_names[semitoneValue(p_semitone)];
 }
 
 //------------------------------------------------------------------------------
 void
 MusicNote::init()
 {
-    m_note_names =
+    m_semitone_names =
     {{ QObject::tr("C").toStdString()
      , QObject::tr("C♯").toStdString()
      , QObject::tr("D").toStdString()
@@ -54,6 +62,35 @@ MusicNote::init()
      , QObject::tr("A♯").toStdString()
      , QObject::tr("B").toStdString()
     }};
+}
+
+//------------------------------------------------------------------------------
+std::string MusicNote::octaveName(int p_octave)
+{
+    std::string l_string;
+
+    for (char l_digit : std::to_string(p_octave))
+    {
+        switch(l_digit)
+        {
+            // Convert characters to corresponding Unicode subscript characters.
+            case '0': l_string += "\u2080"; break;
+            case '1': l_string += "\u2081"; break;
+            case '2': l_string += "\u2082"; break;
+            case '3': l_string += "\u2083"; break;
+            case '4': l_string += "\u2084"; break;
+            case '5': l_string += "\u2085"; break;
+            case '6': l_string += "\u2086"; break;
+            case '7': l_string += "\u2087"; break;
+            case '8': l_string += "\u2088"; break;
+            case '9': l_string += "\u2089"; break;
+            case '+': l_string += "\u208A"; break;
+            case '-': l_string += "\u208B"; break;
+            default: myassert(false); break;
+        }
+    }
+    
+    return l_string;
 }
 
 //------------------------------------------------------------------------------

--- a/music/music_note.cpp
+++ b/music/music_note.cpp
@@ -33,7 +33,7 @@ void MusicNote::initMusicStuff()
 //------------------------------------------------------------------------------
 const std::string & MusicNote::noteName(int p_note)
 {
-    return m_note_names[cycle(p_note, 12)];
+    return m_note_names[semitoneValue(p_note)];
 }
 
 //------------------------------------------------------------------------------
@@ -63,21 +63,21 @@ int MusicNote::noteOctave(int p_note)
 }
 
 //------------------------------------------------------------------------------
-int MusicNote::noteValue(int p_note)
+int MusicNote::semitoneValue(int p_note)
 {
     return cycle(p_note, 12);
 }
 
 //------------------------------------------------------------------------------
-int MusicNote::noteValueInKey(int p_note, int p_key)
+int MusicNote::semitoneValueInKey(int p_note, int p_music_key)
 {
-    return noteValue(p_note - p_key);
+    return semitoneValue(p_note - p_music_key);
 }
 
 //------------------------------------------------------------------------------
-double MusicNote::pitchOffsetInKey(const double & p_pitch, int p_key)
+double MusicNote::pitchOffsetInKey(const double & p_pitch, int p_music_key)
 {
-    return cycle(p_pitch - (double)p_key, 12.0);
+    return cycle(p_pitch - (double)p_music_key, 12.0);
 }
 
 //------------------------------------------------------------------------------
@@ -91,12 +91,12 @@ double MusicNote::temperedPitch(int p_note
         return (double)p_note;
     }
     
-    int l_note_in_key = noteValueInKey(p_note, p_music_key);
+    int l_semitone = semitoneValueInKey(p_note, p_music_key);
     int l_temperament_index = -1;
     
     for (int l_i = 0; l_i < p_music_temperament.size(); l_i++)
     {
-        if (p_music_temperament.noteType(l_i) == l_note_in_key)
+        if (p_music_temperament.noteType(l_i) == l_semitone)
         {
             l_temperament_index = l_i;
             break;
@@ -110,14 +110,14 @@ double MusicNote::temperedPitch(int p_note
     }
     
     double l_temperament_pitch = p_music_temperament.noteOffset(l_temperament_index);
-    double l_tempered_pitch = p_note + (l_temperament_pitch - l_note_in_key);
+    double l_tempered_pitch = p_note + (l_temperament_pitch - l_semitone);
 
 #ifdef DEBUG_PRINTF
     std::cout << ">>> temperedPitch() <<<" << std::endl;
     std::cout << "  nominal pitch = " << p_note << " (" << noteName(p_note) << ")" << std::endl;
     std::cout << "  music key = " << p_music_key << " (" << noteName(p_music_key) << ")" << std::endl;
     std::cout << "  music temperament = " << p_music_temperament.name() << std::endl;
-    std::cout << "  note in key = " << l_note_in_key << std::endl;
+    std::cout << "  semitone = " << l_semitone << std::endl;
     std::cout << "  tempered offset = " << l_temperament_pitch << std::endl;
     std::cout << "  tempered pitch = " << l_tempered_pitch << std::endl;
 #endif // DEBUG_PRINTF
@@ -159,7 +159,7 @@ int MusicNote::closestNote(const double & p_pitch
 //------------------------------------------------------------------------------
 bool MusicNote::isBlackNote(int p_note)
 {
-    switch(cycle(p_note, 12))
+    switch(semitoneValue(p_note))
     {
         case 1:
         case 3:

--- a/music/music_note.cpp
+++ b/music/music_note.cpp
@@ -25,7 +25,7 @@ std::array<std::string, 12> MusicNote::m_note_names;
 //------------------------------------------------------------------------------
 void MusicNote::initMusicStuff()
 {
-    init_note_names();
+    init();
     MusicTemperament::init();
     MusicScale::init();
 }
@@ -38,7 +38,7 @@ const std::string & MusicNote::noteName(int p_note)
 
 //------------------------------------------------------------------------------
 void
-MusicNote::init_note_names()
+MusicNote::init()
 {
     m_note_names =
     {{ QObject::tr("C").toStdString()

--- a/music/music_note.h
+++ b/music/music_note.h
@@ -42,8 +42,12 @@ class MusicNote
 {
   public:
 
-    static
-    const std::string & noteName(int p_note);
+    /**
+     The name of the note within its octave
+     @param p_note The note number (or semitone value)
+     @return The name of the note: C, C♯, ..,, B♭, B.
+    */
+    static const std::string & noteName(int p_note);
 
     /**
      The octave number of the note in Scientific Pitch Notation
@@ -69,7 +73,15 @@ class MusicNote
                                 , int p_music_key = g_music_key_roots[GData::getUniqueInstance().musicKey()]
                                   );
 
-    static double pitchOffsetInKey(const double & p_pitch, int p_music_key);
+    /**
+     The pitch offset relative to the root of the given musical key
+     @param p_pitch The pitch
+     @param p_music_key The musical key (0..11).  If not specified, defaults to the globally selected key: `GData::musicKey()`
+     @return The pitch offset in the range 0.0 <= x < 12.0
+    */
+    static double pitchOffsetInKey(const double & p_pitch
+                                 , int p_music_key = g_music_key_roots[GData::getUniqueInstance().musicKey()]
+                                   );
 
     /**
      The tempered pitch of a note, given the key and temperament
@@ -95,21 +107,25 @@ class MusicNote
                          , const MusicTemperament & p_music_temperament = MusicTemperament::getTemperament(GData::getUniqueInstance().musicTemperament())
                            );
 
+    /**
+     Does the note correspond to a black key on a piano?
+     @param p_note The note number
+     @return True if the note is not in the C Major scale
+    */
+    static bool isBlackNote(int p_note);
+    
     static
     void init_note_names();
 
     /**
-       Converts the frequencies freq (in hertz) into their pitch on the midi scale
-       i.e. the number of semi-tones above C0
-       Note: The note's pitch will contain its fractional part
-       Reference = http://www.borg.com/~jglatt/tutr/notenum.htm
-       @param p_freq The frequency in Hz
-       @return The pitch in fractional part semitones from the midi scale.
+     Converts the frequency (in hertz) to the corresponding pitch on the MIDI scale
+     @param p_freq The frequency in Hz
+     @return The pitch on the MIDI scale
     */
     static inline double freq2pitch(const double & p_freq);
 
     /**
-       Does the opposite of the function above
+     Does the opposite of `freq2pitch()`
     */
     static inline double pitch2freq(const double & p_pitch);
 
@@ -129,7 +145,6 @@ class MusicNote
     [[deprecated("Use closestNote() to convert pitches to notes")]]
     static inline int semitoneValue(const double & p_pitch);
 
-    static bool isBlackNote(int p_note);
     /// @deprecated Use closestNote() to convert pitches to notes
     [[deprecated("Use closestNote() to convert pitches to notes")]]
     static inline bool isBlackNote(const double & p_pitch);

--- a/music/music_note.h
+++ b/music/music_note.h
@@ -1,5 +1,5 @@
 /***************************************************************************
-                          musicnotes.h
+                          music_note.h
                              -------------------
     begin                : 2002
     copyright            : (C) 2002-2005 by Philip McLeod
@@ -38,7 +38,7 @@
  
  You can pass the key and temperament explicitly or rely on the default values, which use the globally selected key and temperament in `GData`
  */
-class music_notes
+class MusicNote
 {
   public:
 
@@ -123,7 +123,7 @@ inline bool isBlackNote(const double & p_pitch);
 
 void initMusicStuff();
 
-#include "musicnotes.hpp"
+#include "music_note.hpp"
 
 #endif // MUSICNOTES_H
 //EOF

--- a/music/music_note.h
+++ b/music/music_note.h
@@ -114,9 +114,6 @@ class MusicNote
     */
     static bool isBlackNote(int p_note);
     
-    static
-    void init_note_names();
-
     /**
      Converts the frequency (in hertz) to the corresponding pitch on the MIDI scale
      @param p_freq The frequency in Hz
@@ -150,6 +147,8 @@ class MusicNote
     static inline bool isBlackNote(const double & p_pitch);
 
     private:
+      static void init();
+
       static std::array<std::string, 12> m_note_names;
 };
 

--- a/music/music_note.h
+++ b/music/music_note.h
@@ -46,11 +46,19 @@ class MusicNote
     const std::string & noteName(int p_note);
 
     /**
+     The octave number of the note in Scientific Pitch Notation
+     @param p_note The note number
+     @return The octave number. Middle C (MIDI note 60) is defined as octave 4.  Note number 0 is in octave -1
+    */
+    static int noteOctave(int p_note);
+
+    /**
     The semitone value of the note within its octave
     @param p_note The note number
     @return The semitone value (0..11), which corresponds to the note letters C, C♯, ..,, B♭, B.
     */
     static int semitoneValue(int p_note);
+
     /**
      The semitone value of the note, transposed into the given musical key
      @param p_note The note number
@@ -104,12 +112,6 @@ class MusicNote
        Does the opposite of the function above
     */
     static inline double pitch2freq(const double & p_pitch);
-
-    /**
-       @param p_note The midi note number
-       @return The note octave. Middle C (midi note 60) is defined as octave 4. Making midi note 0 in octave -1
-    */
-    static int noteOctave(int p_note);
 
     static void initMusicStuff();
     

--- a/music/music_note.h
+++ b/music/music_note.h
@@ -27,7 +27,8 @@
  Helper class for musical notes -- all members are static.
  
  Terminology:
- - A "note" is an integer value that represents a musical note, such as C<SUB>4</SUB>.  The values are MIDI note numbers, e.g. C<SUB>4</SUB> = 60.
+ - A "note" is an integer value that represents a musical note, such as C<SUB>4</SUB>.  The values are [MIDI note numbers](https://newt.phys.unsw.edu.au/jw/notes.html),
+ e.g. C<SUB>4</SUB> = 60.
  - A "pitch" is a floating-point value that represents a musical pitch, also measured on the MIDI scale.
  
  The mapping between note numbers and pitches depends on the key and temperament.
@@ -39,23 +40,24 @@
  You can pass the key and temperament explicitly or rely on the default values, which use the globally selected key and temperament in `GData`.
  
  - A "semitone" is the integer value of the position of the note within the octave (0..11).  It corresponds to the note names C, C♯, ..., B♭, B.
- - An "octave" is the octave number of the note in Scientific Pitch Notation. Middle C (note number 60) is defined as octave 4.  Note number 0 is in octave -1.
+ - An "octave" is the octave number of the note in [Scientific Pitch Notation](https://en.wikipedia.org/wiki/Scientific_pitch_notation).
+ Middle C, or  C<SUB>4</SUB> (note number 60) is defined as octave 4.  Note number 0 is in octave -1.
  */
 class MusicNote
 {
   public:
 
     /**
-     The name of the note, including the octave number
+     The name of the note in [Scientific Pitch Notation](https://en.wikipedia.org/wiki/Scientific_pitch_notation)
      @param p_note The note number
      @return The name of the note: C<SUB>4</SUB>, B♭<SUB>5</SUB>, etc. Uses Unicode characters for sharps, flats and subscript digits
     */
     static std::string noteName(int p_note);
 
     /**
-     The octave number of the note in Scientific Pitch Notation
+     The octave number of the note in [Scientific Pitch Notation](https://en.wikipedia.org/wiki/Scientific_pitch_notation)
      @param p_note The note number
-     @return The octave number. Middle C (note number 60) is defined as octave 4.  Note number 0 is in octave -1
+     @return The octave number. Middle C, or  C<SUB>4</SUB> (note number 60) is defined as octave 4.  Note number 0 is in octave -1
     */
     static int noteOctave(int p_note);
 
@@ -132,7 +134,7 @@ class MusicNote
     static bool isBlackNote(int p_note);
     
     /**
-     Converts the frequency (in hertz) to the corresponding pitch on the MIDI scale
+     Converts the frequency (in Hz) to the corresponding pitch on the MIDI scale using the [MIDI Tuning Standard](https://en.wikipedia.org/wiki/MIDI_tuning_standard)
      @param p_freq The frequency in Hz
      @return The pitch on the MIDI scale
     */

--- a/music/music_note.h
+++ b/music/music_note.h
@@ -45,10 +45,6 @@ class MusicNote
     static
     const std::string & noteName(int p_note);
 
-    /// @deprecated Use closestNote() to convert pitches to notes
-    [[deprecated("Use closestNote() to convert pitches to notes")]]
-    static inline const std::string & noteName(const double & p_pitch);
-
     /**
     The semitone value of the note within its octave
     @param p_note The note number
@@ -114,6 +110,15 @@ class MusicNote
        @return The note octave. Middle C (midi note 60) is defined as octave 4. Making midi note 0 in octave -1
     */
     static int noteOctave(int p_note);
+
+    static void initMusicStuff();
+    
+    // Deprecated member functions (do not remove)
+    
+    /// @deprecated Use closestNote() to convert pitches to notes
+    [[deprecated("Use closestNote() to convert pitches to notes")]]
+    static inline const std::string & noteName(const double & p_pitch);
+
     /// @deprecated Use closestNote() to convert pitches to notes
     [[deprecated("Use closestNote() to convert pitches to notes")]]
     static inline int noteOctave(const double & p_pitch);
@@ -126,9 +131,6 @@ class MusicNote
     /// @deprecated Use closestNote() to convert pitches to notes
     [[deprecated("Use closestNote() to convert pitches to notes")]]
     static inline bool isBlackNote(const double & p_pitch);
-
-
-    static void initMusicStuff();
 
     private:
       static std::array<std::string, 12> m_note_names;

--- a/music/music_note.h
+++ b/music/music_note.h
@@ -27,16 +27,19 @@
  Helper class for musical notes -- all members are static.
  
  Terminology:
- - A "note" is an integer value that represents a musical note, such as C4.  The values are MIDI note numbers, e.g. C4 = 60.
+ - A "note" is an integer value that represents a musical note, such as C<SUB>4</SUB>.  The values are MIDI note numbers, e.g. C<SUB>4</SUB> = 60.
  - A "pitch" is a floating-point value that represents a musical pitch, also measured on the MIDI scale.
  
  The mapping between note numbers and pitches depends on the key and temperament.
- For example, the note G4 (66) in Pythagorean temperament (in the key of C) has a pitch of 66.0196, which is 1.96 cents higher than in even temperament.
+ For example, the note G<SUB>4</SUB> (note number 66) in Pythagorean temperament (in the key of C) has a pitch of 66.0196, which is 1.96 cents higher than in even temperament.
  Only in even temperament do the note numbers correspond to the pitch values.
  - Use `temperedPitch()` to convert from a note number to the corresponding pitch.
- - Use `closestNote()` to convert from a pitch to the closest note number.
+ - Use `closestNote()` to convert from a pitch to the note number of the closest tempered pitch.
  
- You can pass the key and temperament explicitly or rely on the default values, which use the globally selected key and temperament in `GData`
+ You can pass the key and temperament explicitly or rely on the default values, which use the globally selected key and temperament in `GData`.
+ 
+ - A "semitone" is the integer value of the position of the note within its octave (0..11).  It corresponds to the note names C, C♯, ..., B♭, B.
+ - An "octave" is the octave number of the note in Scientific Pitch Notation. Middle C (note number 60) is defined as octave 4.  Note number 0 is in octave -1.
  */
 class MusicNote
 {
@@ -45,21 +48,21 @@ class MusicNote
     /**
      The name of the note within its octave
      @param p_note The note number (or semitone value)
-     @return The name of the note: C, C♯, ..,, B♭, B.
+     @return The name of the note: C, C♯, ..., B♭, B. Uses Unicode characters for sharps and flats.
     */
     static const std::string & noteName(int p_note);
 
     /**
      The octave number of the note in Scientific Pitch Notation
      @param p_note The note number
-     @return The octave number. Middle C (MIDI note 60) is defined as octave 4.  Note number 0 is in octave -1
+     @return The octave number. Middle C (note number 60) is defined as octave 4.  Note number 0 is in octave -1
     */
     static int noteOctave(int p_note);
 
     /**
     The semitone value of the note within its octave
     @param p_note The note number
-    @return The semitone value (0..11), which corresponds to the note letters C, C♯, ..,, B♭, B.
+    @return The semitone value (0..11), which corresponds to the note names C, C♯, ..., B♭, B.
     */
     static int semitoneValue(int p_note);
 
@@ -67,7 +70,7 @@ class MusicNote
      The semitone value of the note, transposed into the given musical key
      @param p_note The note number
      @param p_music_key The musical key (0..11).  If not specified, defaults to the globally selected key: `GData::musicKey()`
-     @return The semitone value (0..11), which corresponds to the note letters C, C♯, ..,, B♭, B.
+     @return The semitone value (0..11), which corresponds to the note names C, C♯, ..., B♭, B.
     */
     static int semitoneValueInKey(int p_note
                                 , int p_music_key = g_music_key_roots[GData::getUniqueInstance().musicKey()]

--- a/music/music_note.h
+++ b/music/music_note.h
@@ -48,8 +48,24 @@ class MusicNote
     /// @deprecated Use closestNote() to convert pitches to notes
     [[deprecated("Use closestNote() to convert pitches to notes")]]
     static inline const std::string & noteName(const double & p_pitch);
-    static int noteValueInKey(int p_note, int p_key);
-    static double pitchOffsetInKey(const double & p_pitch, int p_key);
+
+    /**
+    The semitone value of the note within its octave
+    @param p_note The note number
+    @return The semitone value (0..11), which corresponds to the note letters C, C♯, ..,, B♭, B.
+    */
+    static int semitoneValue(int p_note);
+    /**
+     The semitone value of the note, transposed into the given musical key
+     @param p_note The note number
+     @param p_music_key The musical key (0..11).  If not specified, defaults to the globally selected key: `GData::musicKey()`
+     @return The semitone value (0..11), which corresponds to the note letters C, C♯, ..,, B♭, B.
+    */
+    static int semitoneValueInKey(int p_note
+                                , int p_music_key = g_music_key_roots[GData::getUniqueInstance().musicKey()]
+                                  );
+
+    static double pitchOffsetInKey(const double & p_pitch, int p_music_key);
 
     /**
      The tempered pitch of a note, given the key and temperament
@@ -102,14 +118,9 @@ class MusicNote
     [[deprecated("Use closestNote() to convert pitches to notes")]]
     static inline int noteOctave(const double & p_pitch);
 
-    /**
-       @param p_note The midi note number
-       @return The midi note within one octave. Range = 0 to 11. Where 0=C, 1=C# ... 11 = B.
-    */
-    static int noteValue(int p_note);
     /// @deprecated Use closestNote() to convert pitches to notes
     [[deprecated("Use closestNote() to convert pitches to notes")]]
-    static inline int noteValue(const double & p_pitch);
+    static inline int semitoneValue(const double & p_pitch);
 
     static bool isBlackNote(int p_note);
     /// @deprecated Use closestNote() to convert pitches to notes

--- a/music/music_note.h
+++ b/music/music_note.h
@@ -24,17 +24,17 @@
 #include "music_temperament.h"
 
 /**
- Helper class for musical notes
+ Helper class for musical notes -- all members are static.
  
  Terminology:
  - A "note" is an integer value that represents a musical note, such as C4.  The values are MIDI note numbers, e.g. C4 = 60.
- - A "pitch" is a floating-point value that represents the pitch of the note, also measured on the MIDI scale.
+ - A "pitch" is a floating-point value that represents a musical pitch, also measured on the MIDI scale.
  
  The mapping between note numbers and pitches depends on the key and temperament.
  For example, the note G4 (66) in Pythagorean temperament (in the key of C) has a pitch of 66.0196, which is 1.96 cents higher than in even temperament.
  Only in even temperament do the note numbers correspond to the pitch values.
  - Use `temperedPitch()` to convert from a note number to the corresponding pitch.
- - Use `closestNote()` to convert from a pitch to the corresponding note number.
+ - Use `closestNote()` to convert from a pitch to the closest note number.
  
  You can pass the key and temperament explicitly or rely on the default values, which use the globally selected key and temperament in `GData`
  */
@@ -78,50 +78,50 @@ class MusicNote
     static
     void init_note_names();
 
-  private:
-    static std::array<std::string, 12> m_note_names;
+    /**
+       Converts the frequencies freq (in hertz) into their pitch on the midi scale
+       i.e. the number of semi-tones above C0
+       Note: The note's pitch will contain its fractional part
+       Reference = http://www.borg.com/~jglatt/tutr/notenum.htm
+       @param p_freq The frequency in Hz
+       @return The pitch in fractional part semitones from the midi scale.
+    */
+    static inline double freq2pitch(const double & p_freq);
+
+    /**
+       Does the opposite of the function above
+    */
+    static inline double pitch2freq(const double & p_pitch);
+
+    /**
+       @param p_note The midi note number
+       @return The note octave. Middle C (midi note 60) is defined as octave 4. Making midi note 0 in octave -1
+    */
+    static int noteOctave(int p_note);
+    /// @deprecated Use closestNote() to convert pitches to notes
+    [[deprecated("Use closestNote() to convert pitches to notes")]]
+    static inline int noteOctave(const double & p_pitch);
+
+    /**
+       @param p_note The midi note number
+       @return The midi note within one octave. Range = 0 to 11. Where 0=C, 1=C# ... 11 = B.
+    */
+    static int noteValue(int p_note);
+    /// @deprecated Use closestNote() to convert pitches to notes
+    [[deprecated("Use closestNote() to convert pitches to notes")]]
+    static inline int noteValue(const double & p_pitch);
+
+    static bool isBlackNote(int p_note);
+    /// @deprecated Use closestNote() to convert pitches to notes
+    [[deprecated("Use closestNote() to convert pitches to notes")]]
+    static inline bool isBlackNote(const double & p_pitch);
+
+
+    static void initMusicStuff();
+
+    private:
+      static std::array<std::string, 12> m_note_names;
 };
-
-/**
-   Converts the frequencies freq (in hertz) into their pitch on the midi scale
-   i.e. the number of semi-tones above C0
-   Note: The note's pitch will contain its fractional part
-   Reference = http://www.borg.com/~jglatt/tutr/notenum.htm
-   @param p_freq The frequency in Hz
-   @return The pitch in fractional part semitones from the midi scale.
-*/
-inline double freq2pitch(const double & p_freq);
-
-/**
-   Does the opposite of the function above
-*/
-inline double pitch2freq(const double & p_pitch);
-
-/**
-   @param p_note The midi note number
-   @return The note octave. Middle C (midi note 60) is defined as octave 4. Making midi note 0 in octave -1
-*/
-int noteOctave(int p_note);
-/// @deprecated Use closestNote() to convert pitches to notes
-[[deprecated("Use closestNote() to convert pitches to notes")]]
-inline int noteOctave(const double & p_pitch);
-
-/**
-   @param p_note The midi note number
-   @return The midi note within one octave. Range = 0 to 11. Where 0=C, 1=C# ... 11 = B.
-*/
-int noteValue(int p_note);
-/// @deprecated Use closestNote() to convert pitches to notes
-[[deprecated("Use closestNote() to convert pitches to notes")]]
-inline int noteValue(const double & p_pitch);
-
-bool isBlackNote(int p_note);
-/// @deprecated Use closestNote() to convert pitches to notes
-[[deprecated("Use closestNote() to convert pitches to notes")]]
-inline bool isBlackNote(const double & p_pitch);
-
-
-void initMusicStuff();
 
 #include "music_note.hpp"
 

--- a/music/music_note.h
+++ b/music/music_note.h
@@ -38,7 +38,7 @@
  
  You can pass the key and temperament explicitly or rely on the default values, which use the globally selected key and temperament in `GData`.
  
- - A "semitone" is the integer value of the position of the note within its octave (0..11).  It corresponds to the note names C, C♯, ..., B♭, B.
+ - A "semitone" is the integer value of the position of the note within the octave (0..11).  It corresponds to the note names C, C♯, ..., B♭, B.
  - An "octave" is the octave number of the note in Scientific Pitch Notation. Middle C (note number 60) is defined as octave 4.  Note number 0 is in octave -1.
  */
 class MusicNote
@@ -46,11 +46,11 @@ class MusicNote
   public:
 
     /**
-     The name of the note within its octave
-     @param p_note The note number (or semitone value)
-     @return The name of the note: C, C♯, ..., B♭, B. Uses Unicode characters for sharps and flats.
+     The name of the note, including the octave number
+     @param p_note The note number
+     @return The name of the note: C<SUB>4</SUB>, B♭<SUB>5</SUB>, etc. Uses Unicode characters for sharps, flats and subscript digits
     */
-    static const std::string & noteName(int p_note);
+    static std::string noteName(int p_note);
 
     /**
      The octave number of the note in Scientific Pitch Notation
@@ -60,11 +60,25 @@ class MusicNote
     static int noteOctave(int p_note);
 
     /**
-    The semitone value of the note within its octave
+     The name of the octave, using Unicode subscript digits
+     @param p_octave The octave number
+     @return The name of the octave (e.g. <SUB>4</SUB>). Uses Unicode characters for subscript numbers
+    */
+    static std::string octaveName(int p_octave);
+
+    /**
+    The semitone value of the note within the octave
     @param p_note The note number
     @return The semitone value (0..11), which corresponds to the note names C, C♯, ..., B♭, B.
     */
     static int semitoneValue(int p_note);
+
+    /**
+     The name of the semitone
+     @param p_semitone The semitone value (0..11)
+     @return The name of the semitone: C, C♯, ..., B♭, B. Uses Unicode characters for sharps and flats.
+    */
+    static const std::string & semitoneName(int p_semitone);
 
     /**
      The semitone value of the note, transposed into the given musical key
@@ -135,7 +149,7 @@ class MusicNote
     
     /// @deprecated Use closestNote() to convert pitches to notes
     [[deprecated("Use closestNote() to convert pitches to notes")]]
-    static inline const std::string & noteName(const double & p_pitch);
+    static inline std::string noteName(const double & p_pitch);
 
     /// @deprecated Use closestNote() to convert pitches to notes
     [[deprecated("Use closestNote() to convert pitches to notes")]]
@@ -152,7 +166,7 @@ class MusicNote
     private:
       static void init();
 
-      static std::array<std::string, 12> m_note_names;
+      static std::array<std::string, 12> m_semitone_names;
 };
 
 #include "music_note.hpp"

--- a/music/music_note.hpp
+++ b/music/music_note.hpp
@@ -38,7 +38,7 @@ double MusicNote::pitch2freq(const double & p_pitch)
 }
 
 //------------------------------------------------------------------------------
-const std::string & MusicNote::noteName(const double & p_pitch)
+std::string MusicNote::noteName(const double & p_pitch)
 {
     // This method is deprecated, but don't remove it.
     // Otherwise, a call to `noteName(double)` would use implicit conversions to call `noteName(int)`, which would truncate the pitch value.

--- a/music/music_note.hpp
+++ b/music/music_note.hpp
@@ -38,7 +38,7 @@ double pitch2freq(const double & p_pitch)
 }
 
 //------------------------------------------------------------------------------
-const std::string & music_notes::noteName(const double & p_pitch)
+const std::string & MusicNote::noteName(const double & p_pitch)
 {
     // This method is deprecated, but don't remove it.
     // Otherwise, a call to `noteName(double)` would use implicit conversions to call `noteName(int)`, which would truncate the pitch value.
@@ -50,7 +50,7 @@ int noteOctave(const double & p_pitch)
 {
     // This function is deprecated, but don't remove it.
     // Otherwise, a call to `noteOctave(double)` would use implicit conversions to call `noteOctave(int)`, which would truncate the pitch value.
-    return noteOctave(music_notes::closestNote(p_pitch));
+    return noteOctave(MusicNote::closestNote(p_pitch));
 }
 
 //------------------------------------------------------------------------------
@@ -58,7 +58,7 @@ int noteValue(const double & p_pitch)
 {
     // This function is deprecated, but don't remove it.
     // Otherwise, a call to `noteValue(double)` would use implicit conversions to call `noteValue(int)`, which would truncate the pitch value.
-    return noteValue(music_notes::closestNote(p_pitch));
+    return noteValue(MusicNote::closestNote(p_pitch));
 }
 
 //------------------------------------------------------------------------------
@@ -66,7 +66,7 @@ bool isBlackNote(const double & p_pitch)
 {
     // This function is deprecated, but don't remove it.
     // Otherwise, a call to `isBlackNote(double)` would use implicit conversions to call `isBlackNote(int)`, which would truncate the pitch value.
-    return isBlackNote(music_notes::closestNote(p_pitch));
+    return isBlackNote(MusicNote::closestNote(p_pitch));
 }
 
 //EOF

--- a/music/music_note.hpp
+++ b/music/music_note.hpp
@@ -17,7 +17,7 @@
 */
 
 //------------------------------------------------------------------------------
-double freq2pitch(const double & p_freq)
+double MusicNote::freq2pitch(const double & p_freq)
 {
 #ifdef log2
     //From log rules  log(x/y) = log(x) - log(y)
@@ -31,7 +31,7 @@ double freq2pitch(const double & p_freq)
 }
 
 //------------------------------------------------------------------------------
-double pitch2freq(const double & p_pitch)
+double MusicNote::pitch2freq(const double & p_pitch)
 {
     double l_result = pow10((p_pitch + 36.3763165622959152488) / 39.8631371386483481);
     return l_result;
@@ -46,27 +46,27 @@ const std::string & MusicNote::noteName(const double & p_pitch)
 }
 
 //------------------------------------------------------------------------------
-int noteOctave(const double & p_pitch)
+int MusicNote::noteOctave(const double & p_pitch)
 {
     // This function is deprecated, but don't remove it.
     // Otherwise, a call to `noteOctave(double)` would use implicit conversions to call `noteOctave(int)`, which would truncate the pitch value.
-    return noteOctave(MusicNote::closestNote(p_pitch));
+    return noteOctave(closestNote(p_pitch));
 }
 
 //------------------------------------------------------------------------------
-int noteValue(const double & p_pitch)
+int MusicNote::noteValue(const double & p_pitch)
 {
     // This function is deprecated, but don't remove it.
     // Otherwise, a call to `noteValue(double)` would use implicit conversions to call `noteValue(int)`, which would truncate the pitch value.
-    return noteValue(MusicNote::closestNote(p_pitch));
+    return noteValue(closestNote(p_pitch));
 }
 
 //------------------------------------------------------------------------------
-bool isBlackNote(const double & p_pitch)
+bool MusicNote::isBlackNote(const double & p_pitch)
 {
     // This function is deprecated, but don't remove it.
     // Otherwise, a call to `isBlackNote(double)` would use implicit conversions to call `isBlackNote(int)`, which would truncate the pitch value.
-    return isBlackNote(MusicNote::closestNote(p_pitch));
+    return isBlackNote(closestNote(p_pitch));
 }
 
 //EOF

--- a/music/music_note.hpp
+++ b/music/music_note.hpp
@@ -54,11 +54,11 @@ int MusicNote::noteOctave(const double & p_pitch)
 }
 
 //------------------------------------------------------------------------------
-int MusicNote::noteValue(const double & p_pitch)
+int MusicNote::semitoneValue(const double & p_pitch)
 {
     // This function is deprecated, but don't remove it.
-    // Otherwise, a call to `noteValue(double)` would use implicit conversions to call `noteValue(int)`, which would truncate the pitch value.
-    return noteValue(closestNote(p_pitch));
+    // Otherwise, a call to `semitoneValue(double)` would use implicit conversions to call `semitoneValue(int)`, which would truncate the pitch value.
+    return semitoneValue(closestNote(p_pitch));
 }
 
 //------------------------------------------------------------------------------

--- a/music/music_temperament.cpp
+++ b/music/music_temperament.cpp
@@ -45,10 +45,10 @@ MusicTemperament::MusicTemperament(const std::string & p_name
             break;
             
         case NoteOffsetType::Ratio:
-            const double l_k = freq2pitch(1.0);
+            const double l_k = MusicNote::freq2pitch(1.0);
             for (double & l_note_offset : m_note_offsets)
             {
-                l_note_offset = freq2pitch(l_note_offset) - l_k;
+                l_note_offset = MusicNote::freq2pitch(l_note_offset) - l_k;
             }
             break;
     }

--- a/music/music_temperament.cpp
+++ b/music/music_temperament.cpp
@@ -15,7 +15,7 @@
    Please read LICENSE.txt for details.
  ***************************************************************************/
 #include "music_temperament.h"
-#include "musicnotes.h"
+#include "music_note.h"
 
 //------------------------------------------------------------------------------
 MusicTemperament::MusicTemperament(const std::string & p_name

--- a/pitch.pro
+++ b/pitch.pro
@@ -120,12 +120,12 @@ HEADERS += \
   include/array2d.h \
   include/myassert.h \
   include/RingBuffer.h \
+  music/music_note.h \
+  music/music_note.hpp \
   music/music_scale.h \
   music/music_scale.hpp \
   music/music_temperament.h \
   music/music_temperament.hpp \
-  music/musicnotes.h \
-  music/musicnotes.hpp \
   sound/filters/FastSmoothedAveragingFilter.h \
   sound/filters/Filter.h \
   sound/filters/FixedAveragingFilter.h \
@@ -240,9 +240,9 @@ SOURCES += \
    global/conversions.cpp \
    global/gdata.cpp \
    global/view.cpp \
+   music/music_note.cpp \
    music/music_scale.cpp \
    music/music_temperament.cpp \
-   music/musicnotes.cpp \
    sound/filters/FastSmoothedAveragingFilter.cpp \
    sound/filters/FixedAveragingFilter.cpp \
    sound/filters/GrowingAveragingFilter.cpp \

--- a/sound/channel.cpp
+++ b/sound/channel.cpp
@@ -807,7 +807,7 @@ void Channel::chooseCorrelationIndex1(int p_chunk)
     l_analysis_data.setPeriod(l_analysis_data.getPeriodEstimatesAt(l_choosen_max_index));
     double l_freq = rate() / l_analysis_data.getPeriod();
     l_analysis_data.setFundamentalFreq(float(l_freq));
-    l_analysis_data.setPitch(bound(freq2pitch(l_freq), 0.0, GData::getUniqueInstance().topPitch()));
+    l_analysis_data.setPitch(bound(MusicNote::freq2pitch(l_freq), 0.0, GData::getUniqueInstance().topPitch()));
     l_analysis_data.setPitchSum(static_cast<double>(l_analysis_data.getPitch()));
     l_analysis_data.setPitch2Sum(sq(static_cast<double>(l_analysis_data.getPitch())));
 }
@@ -856,7 +856,7 @@ bool Channel::chooseCorrelationIndex( int p_chunk
     l_analysis_data.setPeriod(l_analysis_data.getPeriodEstimatesAt(l_choosen_max_index));
     double l_freq = rate() / l_analysis_data.getPeriod();
     l_analysis_data.setFundamentalFreq(float(l_freq));
-    l_analysis_data.setPitch(bound(freq2pitch(l_freq), 0.0, GData::getUniqueInstance().topPitch()));
+    l_analysis_data.setPitch(bound(MusicNote::freq2pitch(l_freq), 0.0, GData::getUniqueInstance().topPitch()));
     if(p_chunk > 0 && !isFirstChunkInNote(p_chunk))
     {
         l_analysis_data.setPitchSum(dataAtChunk(p_chunk - 1)->getPitchSum() + static_cast<double>(l_analysis_data.getPitch()));
@@ -1111,7 +1111,7 @@ float Channel::calcDetailedPitch( float * p_input
 
     for(l_j = 0; l_j < l_num; l_j++)
     {
-        l_unsmoothed[l_j] = freq2pitch(rate() / l_unsmoothed[l_j]);
+        l_unsmoothed[l_j] = MusicNote::freq2pitch(rate() / l_unsmoothed[l_j]);
     }
 
     m_pitch_big_smoothing_filter->filter(l_unsmoothed.begin(), m_detailed_pitch_data_smoothed.begin(), l_num);

--- a/sound/channel.cpp
+++ b/sound/channel.cpp
@@ -29,7 +29,7 @@
 #include "FixedAveragingFilter.h"
 #include "GrowingAveragingFilter.h"
 #include "prony.h"
-#include "musicnotes.h"
+#include "music_note.h"
 #include "bspline.h"
 
 const double g_short_time = 0.08;

--- a/sound/notedata.cpp
+++ b/sound/notedata.cpp
@@ -21,7 +21,7 @@
 #include "gdata.h"
 #include "channel.h"
 #include "useful.h"
-#include "musicnotes.h"
+#include "music_note.h"
 
 //------------------------------------------------------------------------------
 NoteData::NoteData(const Channel & p_channel)

--- a/sound/notedata.cpp
+++ b/sound/notedata.cpp
@@ -87,7 +87,7 @@ void NoteData::addData( const AnalysisData & p_analysis_data
     m_max_purity = MAX(m_max_purity, p_analysis_data.getVolumeValue(GData::getUniqueInstance()));
     m_volume = MAX(m_volume, dB2Normalised(p_analysis_data.getLogRms(), GData::getUniqueInstance()));
     m_num_periods += p_periods; //sum up the periods
-    m_avg_pitch = bound(freq2pitch(avgFreq()), 0.0, GData::getUniqueInstance().topPitch());
+    m_avg_pitch = bound(MusicNote::freq2pitch(avgFreq()), 0.0, GData::getUniqueInstance().topPitch());
 }
 
 //------------------------------------------------------------------------------
@@ -251,7 +251,7 @@ void NoteData::recalcAvgPitch()
     {
         m_num_periods += float(m_channel->framesPerChunk()) / float(m_channel->dataAtChunk(l_j)->getPeriod());
     }
-    m_avg_pitch = bound(freq2pitch(avgFreq()), 0.0, GData::getUniqueInstance().topPitch());
+    m_avg_pitch = bound(MusicNote::freq2pitch(avgFreq()), 0.0, GData::getUniqueInstance().topPitch());
 }
 
 // EOF

--- a/widgets/freq/freqwidgetGL.cpp
+++ b/widgets/freq/freqwidgetGL.cpp
@@ -146,7 +146,7 @@ void FreqWidgetGL::drawReferenceLines( QPaintDevice & p_paint_device
             p_painter.setPen(Qt::black);
             l_note_label = QString::fromStdString(MusicNote::noteName(l_name_index) + toSubscriptString(MusicNote::noteOctave(l_name_index)));
             p_painter.drawText(2, l_line_Y + l_font_height_space, l_note_label);
-            if(MusicNote::noteValue(l_name_index) == 0)
+            if(MusicNote::semitoneValue(l_name_index) == 0)
             {
                 p_painter.setPen(QPen(Qt::black, 1, Qt::SolidLine));
             }

--- a/widgets/freq/freqwidgetGL.cpp
+++ b/widgets/freq/freqwidgetGL.cpp
@@ -144,7 +144,7 @@ void FreqWidgetGL::drawReferenceLines( QPaintDevice & p_paint_device
         if(!MusicNote::isBlackNote(l_name_index))
         {
             p_painter.setPen(Qt::black);
-            l_note_label = QString::fromStdString(MusicNote::noteName(l_name_index) + toSubscriptString(MusicNote::noteOctave(l_name_index)));
+            l_note_label = QString::fromStdString(MusicNote::noteName(l_name_index));
             p_painter.drawText(2, l_line_Y + l_font_height_space, l_note_label);
             if(MusicNote::semitoneValue(l_name_index) == 0)
             {
@@ -272,7 +272,7 @@ void FreqWidgetGL::drawReferenceLinesGL( const double & /* p_left_time*/
                 l_line_Y = double(height()) - myround((l_cur_pitch - p_view_bottom) / p_zoom_Y);
                 l_name_index = toInt(l_cur_pitch);
                 glColor3ub(0, 0, 0);
-                l_note_label = QString::fromStdString(MusicNote::noteName(l_name_index) + toSubscriptString(MusicNote::noteOctave(l_name_index)));
+                l_note_label = QString::fromStdString(MusicNote::noteName(l_name_index));
                 renderText(2, toInt(l_line_Y) + l_font_height_space, l_note_label);
             }
             if(p_zoom_Y > 0.1)

--- a/widgets/freq/freqwidgetGL.cpp
+++ b/widgets/freq/freqwidgetGL.cpp
@@ -40,7 +40,7 @@
 #include "useful.h"
 #include "myqt.h"
 #include "array1d.h"
-#include "musicnotes.h"
+#include "music_note.h"
 #include "music_scale.h"
 #include "music_temperament.h"
 
@@ -144,7 +144,7 @@ void FreqWidgetGL::drawReferenceLines( QPaintDevice & p_paint_device
         if(!isBlackNote(l_name_index))
         {
             p_painter.setPen(Qt::black);
-            l_note_label = QString::fromStdString(music_notes::noteName(l_name_index) + toSubscriptString(noteOctave(l_name_index)));
+            l_note_label = QString::fromStdString(MusicNote::noteName(l_name_index) + toSubscriptString(noteOctave(l_name_index)));
             p_painter.drawText(2, l_line_Y + l_font_height_space, l_note_label);
             if(noteValue(l_name_index) == 0)
             {
@@ -272,7 +272,7 @@ void FreqWidgetGL::drawReferenceLinesGL( const double & /* p_left_time*/
                 l_line_Y = double(height()) - myround((l_cur_pitch - p_view_bottom) / p_zoom_Y);
                 l_name_index = toInt(l_cur_pitch);
                 glColor3ub(0, 0, 0);
-                l_note_label = QString::fromStdString(music_notes::noteName(l_name_index) + toSubscriptString(noteOctave(l_name_index)));
+                l_note_label = QString::fromStdString(MusicNote::noteName(l_name_index) + toSubscriptString(noteOctave(l_name_index)));
                 renderText(2, toInt(l_line_Y) + l_font_height_space, l_note_label);
             }
             if(p_zoom_Y > 0.1)

--- a/widgets/freq/freqwidgetGL.cpp
+++ b/widgets/freq/freqwidgetGL.cpp
@@ -141,12 +141,12 @@ void FreqWidgetGL::drawReferenceLines( QPaintDevice & p_paint_device
     for(double l_y = l_start; l_y < l_stop; l_y += l_step, l_name_index+=l_note_jump)
     {
         l_line_Y = p_paint_device.height() - toInt(l_y);
-        if(!isBlackNote(l_name_index))
+        if(!MusicNote::isBlackNote(l_name_index))
         {
             p_painter.setPen(Qt::black);
-            l_note_label = QString::fromStdString(MusicNote::noteName(l_name_index) + toSubscriptString(noteOctave(l_name_index)));
+            l_note_label = QString::fromStdString(MusicNote::noteName(l_name_index) + toSubscriptString(MusicNote::noteOctave(l_name_index)));
             p_painter.drawText(2, l_line_Y + l_font_height_space, l_note_label);
-            if(noteValue(l_name_index) == 0)
+            if(MusicNote::noteValue(l_name_index) == 0)
             {
                 p_painter.setPen(QPen(Qt::black, 1, Qt::SolidLine));
             }
@@ -272,7 +272,7 @@ void FreqWidgetGL::drawReferenceLinesGL( const double & /* p_left_time*/
                 l_line_Y = double(height()) - myround((l_cur_pitch - p_view_bottom) / p_zoom_Y);
                 l_name_index = toInt(l_cur_pitch);
                 glColor3ub(0, 0, 0);
-                l_note_label = QString::fromStdString(MusicNote::noteName(l_name_index) + toSubscriptString(noteOctave(l_name_index)));
+                l_note_label = QString::fromStdString(MusicNote::noteName(l_name_index) + toSubscriptString(MusicNote::noteOctave(l_name_index)));
                 renderText(2, toInt(l_line_Y) + l_font_height_space, l_note_label);
             }
             if(p_zoom_Y > 0.1)

--- a/widgets/htrack/htrackwidget.cpp
+++ b/widgets/htrack/htrackwidget.cpp
@@ -24,7 +24,7 @@
 #include "channel.h"
 #include "array1d.h"
 #include "piano3d.h"
-#include "musicnotes.h"
+#include "music_note.h"
 #include "widget_utils.h"
 #include <glu.h>
 #include <gl.h>

--- a/widgets/htrack/htrackwidget.cpp
+++ b/widgets/htrack/htrackwidget.cpp
@@ -179,7 +179,7 @@ void HTrackWidget::paintGL()
             {
                 for(l_harmonic=0; l_harmonic < l_num_harmonics; l_harmonic++)
                 {
-                    l_pitches(l_harmonic, l_chunk_offset) = freq2pitch(l_data->getHarmonicFreqAt(l_harmonic));
+                    l_pitches(l_harmonic, l_chunk_offset) = MusicNote::freq2pitch(l_data->getHarmonicFreqAt(l_harmonic));
                     l_amps(l_harmonic, l_chunk_offset) = l_data->getHarmonicAmpAt(l_harmonic);
                 }
             }

--- a/widgets/htrack/piano3d.cpp
+++ b/widgets/htrack/piano3d.cpp
@@ -52,13 +52,13 @@ Piano3d::~Piano3d()
 //------------------------------------------------------------------------------
 double Piano3d::pianoWidth()
 {
-    return (isBlackNote(m_num_keys - 1) + m_first_key) ? m_key_offsets[m_num_keys - 1] + m_black_key_width : m_key_offsets[m_num_keys - 1] + m_white_key_width;
+    return (MusicNote::isBlackNote(m_num_keys - 1) + m_first_key) ? m_key_offsets[m_num_keys - 1] + m_black_key_width : m_key_offsets[m_num_keys - 1] + m_white_key_width;
 }
 
 //------------------------------------------------------------------------------
 double Piano3d::offsetAtKey(int p_key_num)
 {
-    return (noteOctave(p_key_num) + 1) * m_octave_width + g_keyOffsetTable[cycle(p_key_num, 12)] - m_first_key_offset;
+    return (MusicNote::noteOctave(p_key_num) + 1) * m_octave_width + g_keyOffsetTable[cycle(p_key_num, 12)] - m_first_key_offset;
 }
 
 //------------------------------------------------------------------------------
@@ -76,7 +76,7 @@ void Piano3d::init( int p_num_keys
     m_first_key = p_first_key;
     m_key_states.resize(m_num_keys, false);
     m_key_offsets.resize(m_num_keys);
-    m_first_key_offset = (noteOctave(m_first_key) + 1) * m_octave_width + g_keyOffsetTable[cycle(m_first_key, 12)];
+    m_first_key_offset = (MusicNote::noteOctave(m_first_key) + 1) * m_octave_width + g_keyOffsetTable[cycle(m_first_key, 12)];
     int l_cur_key;
     for(int l_j = 0; l_j < m_num_keys; l_j++)
     {
@@ -184,7 +184,7 @@ void Piano3d::draw()
     for(l_j = 0; l_j < m_num_keys; l_j++)
     {
         l_cur_key = l_j + m_first_key;
-        if(!isBlackNote(l_cur_key))
+        if(!MusicNote::isBlackNote(l_cur_key))
         {
             if(m_key_states[l_j])
             {
@@ -209,7 +209,7 @@ void Piano3d::draw()
     for(l_j = 0; l_j < m_num_keys; l_j++)
     {
         l_cur_key = l_j + m_first_key;
-        if(isBlackNote(l_cur_key))
+        if(MusicNote::isBlackNote(l_cur_key))
         {
             glPushMatrix();
             glTranslatef(m_key_offsets[l_j], 0.0, 0.0);
@@ -237,7 +237,7 @@ void Piano3d::draw()
     for(l_j = 0; l_j < m_num_keys; l_j++)
     {
         l_cur_key = l_j + m_first_key;
-        if(!isBlackNote(l_cur_key))
+        if(!MusicNote::isBlackNote(l_cur_key))
         {
             if(m_key_states[l_j])
             {
@@ -260,7 +260,7 @@ void Piano3d::draw()
     for(l_j = 0; l_j < m_num_keys; l_j++)
     {
         l_cur_key = l_j + m_first_key;
-        if(isBlackNote(l_cur_key))
+        if(MusicNote::isBlackNote(l_cur_key))
         {
             glPushMatrix();
             glTranslatef(m_key_offsets[l_j], 0.0, 0.0);

--- a/widgets/htrack/piano3d.cpp
+++ b/widgets/htrack/piano3d.cpp
@@ -19,7 +19,7 @@
 
 #include "piano3d.h"
 #include "useful.h"
-#include "musicnotes.h"
+#include "music_note.h"
 
 static double g_keyOffsetTable[12] =
         { 0.0

--- a/widgets/mainwindow/mainwindow.cpp
+++ b/widgets/mainwindow/mainwindow.cpp
@@ -82,7 +82,7 @@
 #include "debugview.h"
 #include "scoreview.h"
 #include "vibratoview.h"
-#include "musicnotes.h"
+#include "music_note.h"
 
 #include "savedialog.h"
 #include "opendialog.h"

--- a/widgets/piano/pianoview.cpp
+++ b/widgets/piano/pianoview.cpp
@@ -60,7 +60,7 @@ void PianoView::changeKey()
             
             // The nominal note that has the closest tempered pitch to p_pitch (used to update the LEDs).
             int l_close_note = MusicNote::closestNote(l_pitch);
-            m_piano_widget->setCurrentNote(noteValue(l_close_note), l_data->getCorrelation());
+            m_piano_widget->setCurrentNote(MusicNote::noteValue(l_close_note), l_data->getCorrelation());
         }
         else
         {

--- a/widgets/piano/pianoview.cpp
+++ b/widgets/piano/pianoview.cpp
@@ -20,7 +20,7 @@
 #include "pianowidget.h"
 #include "gdata.h"
 #include "channel.h"
-#include "musicnotes.h"
+#include "music_note.h"
 
 //------------------------------------------------------------------------------
 PianoView::PianoView( int p_view_id
@@ -59,7 +59,7 @@ void PianoView::changeKey()
             float l_pitch = l_data->getPitch();
             
             // The nominal note that has the closest tempered pitch to p_pitch (used to update the LEDs).
-            int l_close_note = music_notes::closestNote(l_pitch);
+            int l_close_note = MusicNote::closestNote(l_pitch);
             m_piano_widget->setCurrentNote(noteValue(l_close_note), l_data->getCorrelation());
         }
         else

--- a/widgets/piano/pianoview.cpp
+++ b/widgets/piano/pianoview.cpp
@@ -60,7 +60,7 @@ void PianoView::changeKey()
             
             // The nominal note that has the closest tempered pitch to p_pitch (used to update the LEDs).
             int l_close_note = MusicNote::closestNote(l_pitch);
-            m_piano_widget->setCurrentNote(MusicNote::noteValue(l_close_note), l_data->getCorrelation());
+            m_piano_widget->setCurrentNote(MusicNote::semitoneValue(l_close_note), l_data->getCorrelation());
         }
         else
         {

--- a/widgets/pitchcompass/pitchcompassdrawwidget.cpp
+++ b/widgets/pitchcompass/pitchcompassdrawwidget.cpp
@@ -106,7 +106,7 @@ void PitchCompassDrawWidget::setCompassScale()
         {
             if(l_music_scale.hasSemitone(l_index))
             {
-                std::string label = MusicNote::noteName(cycle(l_index + g_music_key_roots[l_music_key], 12));
+                std::string label = MusicNote::semitoneName(cycle(l_index + g_music_key_roots[l_music_key], 12));
                 
                 // Minimize how much the compass resizes due to differences in the lengths of the labels.
                 // Make all of the labels two characters wide.  Don't use regular spaces, since the compass will trim them.
@@ -136,7 +136,7 @@ void PitchCompassDrawWidget::setCompassScale()
         m_compass->setScale(11, 2, 30);
         for(int l_index = 0; l_index < 12; l_index++)
         {
-            l_notes[l_index * 30] = MusicNote::noteName(cycle(l_index + g_music_key_roots[l_music_key], 12));
+            l_notes[l_index * 30] = MusicNote::semitoneName(cycle(l_index + g_music_key_roots[l_music_key], 12));
         }
         m_compass->setLabelMap(l_notes);
 #endif // QWT_VERSION >= 0x060000
@@ -213,9 +213,9 @@ void PitchCompassDrawWidget::updateCompass(double p_time)
             unsigned int l_div = 1;
 #endif // QWT_VERSION >= 0x060000
 
-            l_notes[(l_interval * 3 ) / l_div] = QString::fromStdString(MusicNote::noteName(toInt(l_zero_val)));
-            l_notes[0 / l_div] = QString::fromStdString(MusicNote::noteName(toInt(l_zero_val += 2)));
-            l_notes[l_interval / l_div] = QString::fromStdString(MusicNote::noteName(toInt(l_zero_val)));
+            l_notes[(l_interval * 3 ) / l_div] = QString::fromStdString(MusicNote::semitoneName(toInt(l_zero_val)));
+            l_notes[0 / l_div] = QString::fromStdString(MusicNote::semitoneName(toInt(l_zero_val += 2)));
+            l_notes[l_interval / l_div] = QString::fromStdString(MusicNote::semitoneName(toInt(l_zero_val)));
 
 #if QWT_VERSION >= 0x060000
             QwtCompassScaleDraw * l_scale_draw = dynamic_cast<QwtCompassScaleDraw*>(m_compass->scaleDraw());
@@ -240,9 +240,9 @@ void PitchCompassDrawWidget::updateCompass(double p_time)
                 l_start = fmod(l_start, 360.0);
             }
 
-            l_notes[l_start] = QString::fromStdString(MusicNote::noteName(toInt(l_close_pitch)));
-            l_notes[l_start - l_interval] = QString::fromStdString(MusicNote::noteName(toInt(l_close_pitch - 1)));
-            l_notes[l_start + l_interval] = QString::fromStdString(MusicNote::noteName(toInt(l_close_pitch + 1)));
+            l_notes[l_start] = QString::fromStdString(MusicNote::semitoneName(toInt(l_close_pitch)));
+            l_notes[l_start - l_interval] = QString::fromStdString(MusicNote::semitoneName(toInt(l_close_pitch - 1)));
+            l_notes[l_start + l_interval] = QString::fromStdString(MusicNote::semitoneName(toInt(l_close_pitch + 1)));
 
 #if QWT_VERSION >= 0x060000
             QwtCompassScaleDraw * l_scale_draw = dynamic_cast<QwtCompassScaleDraw*>(m_compass->scaleDraw());

--- a/widgets/pitchcompass/pitchcompassdrawwidget.cpp
+++ b/widgets/pitchcompass/pitchcompassdrawwidget.cpp
@@ -18,7 +18,7 @@
 #include "pitchcompassdrawwidget.h"
 #include "channel.h"
 #include "gdata.h"
-#include "musicnotes.h"
+#include "music_note.h"
 
 #include <QMap>
 #include <QString>
@@ -106,7 +106,7 @@ void PitchCompassDrawWidget::setCompassScale()
         {
             if(l_music_scale.hasSemitone(l_index))
             {
-                std::string label = music_notes::noteName(cycle(l_index + g_music_key_roots[l_music_key], 12));
+                std::string label = MusicNote::noteName(cycle(l_index + g_music_key_roots[l_music_key], 12));
                 
                 // Minimize how much the compass resizes due to differences in the lengths of the labels.
                 // Make all of the labels two characters wide.  Don't use regular spaces, since the compass will trim them.
@@ -136,7 +136,7 @@ void PitchCompassDrawWidget::setCompassScale()
         m_compass->setScale(11, 2, 30);
         for(int l_index = 0; l_index < 12; l_index++)
         {
-            l_notes[l_index * 30] = music_notes::noteName(cycle(l_index + g_music_key_roots[l_music_key], 12));
+            l_notes[l_index * 30] = MusicNote::noteName(cycle(l_index + g_music_key_roots[l_music_key], 12));
         }
         m_compass->setLabelMap(l_notes);
 #endif // QWT_VERSION >= 0x060000
@@ -213,9 +213,9 @@ void PitchCompassDrawWidget::updateCompass(double p_time)
             unsigned int l_div = 1;
 #endif // QWT_VERSION >= 0x060000
 
-            l_notes[(l_interval * 3 ) / l_div] = QString::fromStdString(music_notes::noteName(toInt(l_zero_val)));
-            l_notes[0 / l_div] = QString::fromStdString(music_notes::noteName(toInt(l_zero_val += 2)));
-            l_notes[l_interval / l_div] = QString::fromStdString(music_notes::noteName(toInt(l_zero_val)));
+            l_notes[(l_interval * 3 ) / l_div] = QString::fromStdString(MusicNote::noteName(toInt(l_zero_val)));
+            l_notes[0 / l_div] = QString::fromStdString(MusicNote::noteName(toInt(l_zero_val += 2)));
+            l_notes[l_interval / l_div] = QString::fromStdString(MusicNote::noteName(toInt(l_zero_val)));
 
 #if QWT_VERSION >= 0x060000
             QwtCompassScaleDraw * l_scale_draw = dynamic_cast<QwtCompassScaleDraw*>(m_compass->scaleDraw());
@@ -240,9 +240,9 @@ void PitchCompassDrawWidget::updateCompass(double p_time)
                 l_start = fmod(l_start, 360.0);
             }
 
-            l_notes[l_start] = QString::fromStdString(music_notes::noteName(toInt(l_close_pitch)));
-            l_notes[l_start - l_interval] = QString::fromStdString(music_notes::noteName(toInt(l_close_pitch - 1)));
-            l_notes[l_start + l_interval] = QString::fromStdString(music_notes::noteName(toInt(l_close_pitch + 1)));
+            l_notes[l_start] = QString::fromStdString(MusicNote::noteName(toInt(l_close_pitch)));
+            l_notes[l_start - l_interval] = QString::fromStdString(MusicNote::noteName(toInt(l_close_pitch - 1)));
+            l_notes[l_start + l_interval] = QString::fromStdString(MusicNote::noteName(toInt(l_close_pitch + 1)));
 
 #if QWT_VERSION >= 0x060000
             QwtCompassScaleDraw * l_scale_draw = dynamic_cast<QwtCompassScaleDraw*>(m_compass->scaleDraw());

--- a/widgets/score/scorewidget.cpp
+++ b/widgets/score/scorewidget.cpp
@@ -60,7 +60,7 @@ ScoreWidget::ScoreWidget(QWidget *p_parent)
     for(int l_j = 0; l_j <= 128; l_j++)
     {
         m_flats_lookup[l_j] = l_counter;
-        if(!isBlackNote(l_j))
+        if(!MusicNote::isBlackNote(l_j))
         {
             l_counter++;
         }
@@ -217,7 +217,7 @@ void ScoreWidget::drawNoteAtPitch( int p_x
     {
         l_y_Steps = m_flats_lookup[p_pitch];
         l_y_offset = toInt(m_scale_Y * static_cast<double>(l_y_Steps) * 0.5);
-        if(isBlackNote(p_pitch))
+        if(MusicNote::isBlackNote(p_pitch))
         {
             get_painter().drawText(p_x - l_accidental_offset_X - m_font_width, p_y - l_y_offset + m_font_height / 2, "♭");
         }
@@ -226,7 +226,7 @@ void ScoreWidget::drawNoteAtPitch( int p_x
     {
         l_y_Steps = m_sharps_lookup[p_pitch];
         l_y_offset = toInt(m_scale_Y * static_cast<double>(l_y_Steps) * 0.5);
-        if(isBlackNote(p_pitch))
+        if(MusicNote::isBlackNote(p_pitch))
         {
             get_painter().drawText(p_x - l_accidental_offset_X - m_font_width, p_y - l_y_offset + m_font_height / 2, "♯");
         }

--- a/widgets/score/scorewidget.cpp
+++ b/widgets/score/scorewidget.cpp
@@ -28,7 +28,7 @@
 #include "qfontmetrics.h"
 #include "qpen.h"
 #include "scoresegmentiterator.h"
-#include "musicnotes.h"
+#include "music_note.h"
 
 //------------------------------------------------------------------------------
 ScoreWidget::ScoreWidget(QWidget *p_parent)

--- a/widgets/tuner/tunerview.cpp
+++ b/widgets/tuner/tunerview.cpp
@@ -27,7 +27,7 @@
 #include "useful.h"
 #include "gdata.h"
 #include "channel.h"
-#include "musicnotes.h"
+#include "music_note.h"
 
 //------------------------------------------------------------------------------
 TunerView::TunerView(int p_view_iD_

--- a/widgets/vibrato/vibratotunerwidget.cpp
+++ b/widgets/vibrato/vibratotunerwidget.cpp
@@ -323,7 +323,7 @@ void VibratoTunerWidget::doUpdate(double p_pitch)
             // Pitch, draw the needle this update
             int l_VTLED_letter_lookup[12] = { 2, 2, 3, 3, 4, 5, 5, 6, 6, 0, 0, 1 };
             resetLeds();
-            emit(ledSet(l_VTLED_letter_lookup[MusicNote::noteValue(l_close_note)], true));
+            emit(ledSet(l_VTLED_letter_lookup[MusicNote::semitoneValue(l_close_note)], true));
 
             if(MusicNote::isBlackNote(l_close_note))
             {

--- a/widgets/vibrato/vibratotunerwidget.cpp
+++ b/widgets/vibrato/vibratotunerwidget.cpp
@@ -18,7 +18,7 @@
 #include "gdata.h"
 #include "channel.h"
 #include "analysisdata.h"
-#include "musicnotes.h"
+#include "music_note.h"
 #include <glu.h>
 #include <gl.h>
 #include <QtGlobal>
@@ -283,16 +283,16 @@ void VibratoTunerWidget::doUpdate(double p_pitch)
     m_cur_pitch = p_pitch;
 
     // The nominal note that has the closest tempered pitch to p_pitch (used to update the LEDs).
-    int l_close_note = music_notes::closestNote(p_pitch);
+    int l_close_note = MusicNote::closestNote(p_pitch);
     // The tempered pitch associated with the nominal note value (used for the needle).
-    double l_close_pitch = music_notes::temperedPitch(l_close_note);
+    double l_close_pitch = MusicNote::temperedPitch(l_close_note);
     float l_needle_value = 100 * (p_pitch - l_close_pitch);
 
 #ifdef DEBUG_PRINTF
     std::cout << ">>> VibratoTunerWidget::doUpdate() <<<" << std::endl;
     std::cout << "  input pitch = " << p_pitch << std::endl;
     std::cout << "  music temperament = " << l_music_temperament.name() << std::endl;
-    std::cout << "  closest note = " << l_close_note << " (" << music_notes::noteName(l_close_note) << ")" << std::endl;
+    std::cout << "  closest note = " << l_close_note << " (" << MusicNote::noteName(l_close_note) << ")" << std::endl;
     std::cout << "  tempered pitch of closest note = " << l_close_pitch << std::endl;
     std::cout << "  needle value = " << l_needle_value << std::endl;
 #endif // DEBUG_PRINTF

--- a/widgets/vibrato/vibratotunerwidget.cpp
+++ b/widgets/vibrato/vibratotunerwidget.cpp
@@ -323,9 +323,9 @@ void VibratoTunerWidget::doUpdate(double p_pitch)
             // Pitch, draw the needle this update
             int l_VTLED_letter_lookup[12] = { 2, 2, 3, 3, 4, 5, 5, 6, 6, 0, 0, 1 };
             resetLeds();
-            emit(ledSet(l_VTLED_letter_lookup[noteValue(l_close_note)], true));
+            emit(ledSet(l_VTLED_letter_lookup[MusicNote::noteValue(l_close_note)], true));
 
-            if(isBlackNote(l_close_note))
+            if(MusicNote::isBlackNote(l_close_note))
             {
                 emit(ledSet(7, true));
             }

--- a/widgets/vibrato/vibratowidget.cpp
+++ b/widgets/vibrato/vibratowidget.cpp
@@ -940,11 +940,11 @@ void VibratoWidget::compose_note_label(QString & p_note_label, const int & p_not
   std::stringstream l_composed_note_label;
   if ((MusicNote::noteOctave(p_note) >= 0) && (MusicNote::noteOctave(p_note) <= 9))
     {
-      l_composed_note_label << MusicNote::noteName(p_note) << toSubscriptString(MusicNote::noteOctave(p_note));
+      l_composed_note_label << MusicNote::noteName(p_note);
     }
   else
     {
-      l_composed_note_label << MusicNote::noteName(p_note) << " ";
+        l_composed_note_label << MusicNote::semitoneName(MusicNote::semitoneValue(p_note)) << " ";
     }
   p_note_label = QString::fromStdString(l_composed_note_label.str());
 }

--- a/widgets/vibrato/vibratowidget.cpp
+++ b/widgets/vibrato/vibratowidget.cpp
@@ -938,9 +938,9 @@ QSize VibratoWidget::sizeHint() const
 void VibratoWidget::compose_note_label(QString & p_note_label, const int & p_note)
 {
   std::stringstream l_composed_note_label;
-  if ((noteOctave(p_note) >= 0) && (noteOctave(p_note) <= 9))
+  if ((MusicNote::noteOctave(p_note) >= 0) && (MusicNote::noteOctave(p_note) <= 9))
     {
-      l_composed_note_label << MusicNote::noteName(p_note) << toSubscriptString(noteOctave(p_note));
+      l_composed_note_label << MusicNote::noteName(p_note) << toSubscriptString(MusicNote::noteOctave(p_note));
     }
   else
     {

--- a/widgets/vibrato/vibratowidget.cpp
+++ b/widgets/vibrato/vibratowidget.cpp
@@ -20,7 +20,7 @@
 #include "gdata.h"
 #include "channel.h"
 #include "analysisdata.h"
-#include "musicnotes.h"
+#include "music_note.h"
 #include <glu.h>
 #include <gl.h>
 #include <sstream>
@@ -940,11 +940,11 @@ void VibratoWidget::compose_note_label(QString & p_note_label, const int & p_not
   std::stringstream l_composed_note_label;
   if ((noteOctave(p_note) >= 0) && (noteOctave(p_note) <= 9))
     {
-      l_composed_note_label << music_notes::noteName(p_note) << toSubscriptString(noteOctave(p_note));
+      l_composed_note_label << MusicNote::noteName(p_note) << toSubscriptString(noteOctave(p_note));
     }
   else
     {
-      l_composed_note_label << music_notes::noteName(p_note) << " ";
+      l_composed_note_label << MusicNote::noteName(p_note) << " ";
     }
   p_note_label = QString::fromStdString(l_composed_note_label.str());
 }


### PR DESCRIPTION
- Rename `music_notes` class to `MusicNote`
- Rename files `musicnotes.*` to `music_note.*`
- Change static functions in `music_note.h` to static members of `MusicNote` class
- Update all callers
- docstring updates
- Rename `noteValue()` to `semitoneValue()`
- Move deprecated functions to the bottom of `MusicNote` class
- Add docs for `MusicNote::noteOctave`
- Add docstrings for members of `MusicNote`
Make `MusicNote::init()` private