### PR TITLE
Update all widgets to take the A=440 reference tuning spinbox into account

### DIFF
--- a/global/gdata.cpp
+++ b/global/gdata.cpp
@@ -929,7 +929,7 @@ void GData::setMusicTemperament(MusicTemperament::TemperamentType p_music_temper
 {
     if(m_music_temperament != p_music_temperament)
     {
-        // If the current key type is not compatible with the new tempered type, then set the key type to Chromatic.
+        // If the current music scale is not compatible with the new tempered type, then set the music scale to Chromatic.
         if(!MusicScale::getScale(m_music_scale).isCompatibleWithTemparament(p_music_temperament))
         {
             setMusicScale(MusicScale::ScaleType::Chromatic);
@@ -940,11 +940,15 @@ void GData::setMusicTemperament(MusicTemperament::TemperamentType p_music_temper
 }
 
 //------------------------------------------------------------------------------
-void GData::setFreqA(double p_x)
+void GData::setFreqA(double p_freq)
 {
-    m_freq_A = p_x;
-    m_semitone_offset = MusicNote::freq2pitch(p_x) - MusicNote::freq2pitch(440.0);
-    m_settings->setValue("View/freqA", p_x);
+    if (m_freq_A != p_freq)
+    {
+        m_freq_A = p_freq;
+        m_semitone_offset = MusicNote::freq2pitch(p_freq) - MusicNote::freq2pitch(440.0);
+        m_settings->setValue("View/freqA", p_freq);
+        emit freqAChanged(p_freq);
+    }
 }
 
 //EOF

--- a/global/gdata.h
+++ b/global/gdata.h
@@ -285,6 +285,7 @@ signals:
   void musicKeyChanged(int p_music_key);
   void musicScaleChanged(int p_music_scale);
   void musicTemperamentChanged(int p_music_temperament);
+  void freqAChanged(double p_freq);
 
 public slots:
 
@@ -301,8 +302,8 @@ public slots:
   inline void setMusicScale(MusicScale::ScaleType p_music_scale);
   void setMusicTemperament(int p_music_temperament);
   void setMusicTemperament(MusicTemperament::TemperamentType p_music_temperament);
-  void setFreqA(double p_x);
-  inline void setFreqA(int p_x);
+  void setFreqA(double p_freq);
+  inline void setFreqA(int p_freq);
 
   void pauseSound();
   bool openPlayRecord( SoundFile * p_sound_file_rec

--- a/music/music_note.cpp
+++ b/music/music_note.cpp
@@ -121,11 +121,12 @@ double MusicNote::pitchOffsetInKey(const double & p_pitch, int p_music_key)
 double MusicNote::temperedPitch(int p_note
                                 , int p_music_key
                                 , const MusicTemperament & p_music_temperament
+                                , double p_semitone_offset
                                   )
 {
     if (p_music_temperament.isEvenTempered())
     {
-        return (double)p_note;
+        return (double)p_note + p_semitone_offset;
     }
     
     int l_semitone = semitoneValueInKey(p_note, p_music_key);
@@ -147,7 +148,7 @@ double MusicNote::temperedPitch(int p_note
     }
     
     double l_temperament_pitch = p_music_temperament.noteOffset(l_temperament_index);
-    double l_tempered_pitch = p_note + (l_temperament_pitch - l_semitone);
+    double l_tempered_pitch = p_note + (l_temperament_pitch - l_semitone) + p_semitone_offset;
 
 #ifdef DEBUG_PRINTF
     std::cout << ">>> temperedPitch() <<<" << std::endl;
@@ -156,6 +157,7 @@ double MusicNote::temperedPitch(int p_note
     std::cout << "  music temperament = " << p_music_temperament.name() << std::endl;
     std::cout << "  semitone = " << l_semitone << std::endl;
     std::cout << "  tempered offset = " << l_temperament_pitch << std::endl;
+    std::cout << "  semitone offset = " << p_semitone_offset << std::endl;
     std::cout << "  tempered pitch = " << l_tempered_pitch << std::endl;
 #endif // DEBUG_PRINTF
     
@@ -167,14 +169,15 @@ double MusicNote::temperedPitch(int p_note
 int MusicNote::closestNote(const double & p_pitch
                            , int p_music_key
                            , const MusicTemperament & p_music_temperament
+                           , double p_semitone_offset
                              )
 {
     if (p_music_temperament.isEvenTempered())
     {
-        return toInt(p_pitch);
+        return toInt(p_pitch - p_semitone_offset);
     }
     
-    double l_offset_in_key = pitchOffsetInKey(p_pitch, p_music_key);
+    double l_offset_in_key = pitchOffsetInKey(p_pitch - p_semitone_offset, p_music_key);
     int l_closest_offset = p_music_temperament.nearestNoteType(l_offset_in_key);
     int l_root_of_key = toInt(p_pitch - l_offset_in_key);
     double l_closest_note = l_root_of_key + l_closest_offset;
@@ -182,6 +185,7 @@ int MusicNote::closestNote(const double & p_pitch
 #ifdef DEBUG_PRINTF
     std::cout << ">>> closestNote() <<<" << std::endl;
     std::cout << "  input pitch = " << p_pitch << std::endl;
+    std::cout << "  semitone offset = " << p_semitone_offset << std::endl;
     std::cout << "  music key = " << p_music_key << " (" << noteName(p_music_key) << ")" << std::endl;
     std::cout << "  music temperament = " << p_music_temperament.name() << std::endl;
     std::cout << "  offset in key = " << l_offset_in_key << std::endl;

--- a/music/music_note.h
+++ b/music/music_note.h
@@ -31,9 +31,9 @@
  e.g. C<SUB>4</SUB> = 60.
  - A "pitch" is a floating-point value that represents a musical pitch, also measured on the MIDI scale.
  
- The mapping between note numbers and pitches depends on the key and temperament.
+ The mapping between note numbers and pitches depends on the key, the temperament, and the tuning reference pitch A<SUB>4</SUB>.
  For example, the note G<SUB>4</SUB> (note number 66) in Pythagorean temperament (in the key of C) has a pitch of 66.0196, which is 1.96 cents higher than in even temperament.
- Only in even temperament do the note numbers correspond to the pitch values.
+ Note numbers only correspond numerically to pitch values when using even temperament and when the tuning reference pitch A<SUB>4</SUB> = 440.
  - Use `temperedPitch()` to convert from a note number to the corresponding pitch.
  - Use `closestNote()` to convert from a pitch to the note number of the closest tempered pitch.
  
@@ -107,11 +107,13 @@ class MusicNote
      @param p_note The note number
      @param p_music_key The musical key (0..11).  If not specified, defaults to the globally selected key: `GData::musicKey()`
      @param p_music_temperament The musical temperament.  If not specified, defaults to the globally selected temperament: `GData::musicTemperament()`
+     @param p_semitone_offset The tuning offset from A<SUB>4</SUB> = 440 in semitones.   If not specified, defaults to the globally selected temperament: `GData::semitoneOffset()`
      @return The tempered pitch.  Returns 0 if the temperament does not include the note
     */
     static double temperedPitch(int p_note
                               , int p_music_key = g_music_key_roots[GData::getUniqueInstance().musicKey()]
                               , const MusicTemperament & p_music_temperament = MusicTemperament::getTemperament(GData::getUniqueInstance().musicTemperament())
+                              , double p_semitone_offset = GData::getUniqueInstance().semitoneOffset()
                                 );
 
     /**
@@ -119,11 +121,13 @@ class MusicNote
      @param p_pitch The pitch
      @param p_music_key The musical key (0..11).  If not specified, defaults to the globally selected key: `GData::musicKey()`
      @param p_music_temperament The musical temperament.  If not specified, defaults to the globally selected temperament: `GData::musicTemperament()`
+     @param p_semitone_offset The tuning offset from A<SUB>4</SUB> = 440 in semitones.   If not specified, defaults to the globally selected temperament: `GData::semitoneOffset()`
      @return The note associated with the closest pitch in the temperament
     */
     static int closestNote(const double & p_pitch
                          , int p_music_key = g_music_key_roots[GData::getUniqueInstance().musicKey()]
                          , const MusicTemperament & p_music_temperament = MusicTemperament::getTemperament(GData::getUniqueInstance().musicTemperament())
+                         , double p_semitone_offset = GData::getUniqueInstance().semitoneOffset()
                            );
 
     /**

--- a/widgets/mainwindow/mainwindow.cpp
+++ b/widgets/mainwindow/mainwindow.cpp
@@ -494,7 +494,7 @@ MainWindow::MainWindow()
     l_freq_A_spin_box->setValue(toInt(GData::getUniqueInstance().freqA()));
     l_freq_A_tool_bar->addWidget(l_freq_A_spin_box);
     connect(l_freq_A_spin_box, SIGNAL(valueChanged(int)), &GData::getUniqueInstance(), SLOT(setFreqA(int)));
-    connect(l_freq_A_spin_box, SIGNAL(valueChanged(int)), &(GData::getUniqueInstance().getView()), SLOT(doUpdate()));
+    connect(&GData::getUniqueInstance(), SIGNAL(freqAChanged(double)), &(GData::getUniqueInstance().getView()), SLOT(doUpdate()));
 
     m_note_label = new MyLabel("Note: 9999", statusBar(), "notelabel");
     statusBar()->addPermanentWidget(m_note_label, 0);

--- a/widgets/pitchcompass/pitchcompassdrawwidget.cpp
+++ b/widgets/pitchcompass/pitchcompassdrawwidget.cpp
@@ -195,7 +195,7 @@ void PitchCompassDrawWidget::updateCompass(double p_time)
     
     if(l_data && l_data->getCorrelation() >= 0.9)
     {
-        double l_pitch = l_data->getPitch();
+        double l_pitch = l_data->getPitch() - GData::getUniqueInstance().semitoneOffset();
         unsigned int l_interval = 90;
 
         if(m_mode == PitchCompassView::CompassMode::Mode0)

--- a/widgets/tuner/tunerview.cpp
+++ b/widgets/tuner/tunerview.cpp
@@ -95,6 +95,7 @@ TunerView::TunerView(int p_view_iD_
     connect(&GData::getUniqueInstance(), SIGNAL(onChunkUpdate()), this, SLOT(doUpdate()));
     connect(&GData::getUniqueInstance(), SIGNAL(musicKeyChanged(int)), this, SLOT(doUpdate()));
     connect(&GData::getUniqueInstance(), SIGNAL(musicTemperamentChanged(int)), this, SLOT(doUpdate()));
+    connect(&GData::getUniqueInstance(), SIGNAL(freqAChanged(double)), this, SLOT(doUpdate()));
     connect(m_tuner_widget, SIGNAL(ledSet(int, bool)), this, SLOT(setLed(int, bool)));
 }
 


### PR DESCRIPTION
- Take tuning offset (from A=440) into account in `MusicNote`
- Update `GData::setFreqA()` to emit `freqAChanged(double)` signal
- Update `TunerView` on `freqAChanged(double)` signal
- Update Pitch Compass to take tuning reference into account
- Connect the main view to the `freqAChanged(double)` signal rather than the A=440 spinbox