### PR TITLE
Fix all compass modes

### DIFF
--- a/music/music_note.cpp
+++ b/music/music_note.cpp
@@ -112,9 +112,12 @@ int MusicNote::semitoneValueInKey(int p_note, int p_music_key)
 }
 
 //------------------------------------------------------------------------------
-double MusicNote::pitchOffsetInKey(const double & p_pitch, int p_music_key)
+double MusicNote::pitchOffsetInKey(const double & p_pitch
+                                 , int p_music_key
+                                 , double p_semitone_offset
+                                   )
 {
-    return cycle(p_pitch - (double)p_music_key, 12.0);
+    return cycle(p_pitch - (double)p_music_key - p_semitone_offset, 12.0);
 }
 
 //------------------------------------------------------------------------------
@@ -177,7 +180,7 @@ int MusicNote::closestNote(const double & p_pitch
         return toInt(p_pitch - p_semitone_offset);
     }
     
-    double l_offset_in_key = pitchOffsetInKey(p_pitch - p_semitone_offset, p_music_key);
+    double l_offset_in_key = pitchOffsetInKey(p_pitch, p_music_key, p_semitone_offset);
     int l_closest_offset = p_music_temperament.nearestNoteType(l_offset_in_key);
     int l_root_of_key = toInt(p_pitch - l_offset_in_key);
     double l_closest_note = l_root_of_key + l_closest_offset;

--- a/music/music_note.h
+++ b/music/music_note.h
@@ -96,10 +96,12 @@ class MusicNote
      The pitch offset relative to the root of the given musical key
      @param p_pitch The pitch
      @param p_music_key The musical key (0..11).  If not specified, defaults to the globally selected key: `GData::musicKey()`
+     @param p_semitone_offset The tuning offset from A<SUB>4</SUB> = 440 in semitones.   If not specified, defaults to the globally selected temperament: `GData::semitoneOffset()`
      @return The pitch offset in the range 0.0 <= x < 12.0
     */
     static double pitchOffsetInKey(const double & p_pitch
                                  , int p_music_key = g_music_key_roots[GData::getUniqueInstance().musicKey()]
+                                 , double p_semitone_offset = GData::getUniqueInstance().semitoneOffset()
                                    );
 
     /**

--- a/widgets/pitchcompass/pitchcompassdrawwidget.cpp
+++ b/widgets/pitchcompass/pitchcompassdrawwidget.cpp
@@ -201,17 +201,18 @@ void PitchCompassDrawWidget::updateCompass(double p_time)
         if(m_mode == PitchCompassView::CompassMode::Mode0)
         {
             QMap< double, QString > l_notes;
-            double l_zero_val = myround(l_pitch);
-            double l_value = (l_pitch - l_zero_val) * l_interval;
+            int l_zero_note = MusicNote::closestNote(l_pitch);
+            double l_zero_pitch = MusicNote::temperedPitch(l_zero_note);
+            double l_value = (l_pitch - l_zero_pitch) * l_interval;
             m_compass->setValue(l_value);
 
             // With Qwt 6.x the map values should match the scale
             // In mode 0 scale is 36 isntead of 360 so need to divide keys by 10
             unsigned int l_div = 10;
 
-            l_notes[(l_interval * 3 ) / l_div] = QString::fromStdString(MusicNote::semitoneName(toInt(l_zero_val)));
-            l_notes[0 / l_div] = QString::fromStdString(MusicNote::semitoneName(toInt(l_zero_val += 2)));
-            l_notes[l_interval / l_div] = QString::fromStdString(MusicNote::semitoneName(toInt(l_zero_val)));
+            l_notes[(l_interval * 3 ) / l_div] = QString::fromStdString(MusicNote::semitoneName(MusicNote::semitoneValue(l_zero_note)));
+            l_notes[0 / l_div] = QString::fromStdString(MusicNote::semitoneName(MusicNote::semitoneValue(l_zero_note += 2)));
+            l_notes[l_interval / l_div] = QString::fromStdString(MusicNote::semitoneName(MusicNote::semitoneValue(l_zero_note)));
 
             QwtCompassScaleDraw * l_scale_draw = dynamic_cast<QwtCompassScaleDraw*>(m_compass->scaleDraw());
             myassert(l_scale_draw);
@@ -220,7 +221,8 @@ void PitchCompassDrawWidget::updateCompass(double p_time)
         else if(m_mode == PitchCompassView::CompassMode::Mode1)
         {
             QMap< double, QString > l_notes;
-            double l_close_pitch = myround(l_pitch);
+            int l_close_note = MusicNote::closestNote(l_pitch);
+            double l_close_pitch = MusicNote::temperedPitch(l_close_note);
             double l_start = toInt((l_close_pitch - l_pitch) * l_interval);
 
             if(l_start < 0)
@@ -232,9 +234,9 @@ void PitchCompassDrawWidget::updateCompass(double p_time)
                 l_start = fmod(l_start, 360.0);
             }
 
-            l_notes[l_start] = QString::fromStdString(MusicNote::semitoneName(toInt(l_close_pitch)));
-            l_notes[l_start - l_interval] = QString::fromStdString(MusicNote::semitoneName(toInt(l_close_pitch - 1)));
-            l_notes[l_start + l_interval] = QString::fromStdString(MusicNote::semitoneName(toInt(l_close_pitch + 1)));
+            l_notes[l_start] = QString::fromStdString(MusicNote::semitoneName(MusicNote::semitoneValue(l_close_note)));
+            l_notes[l_start - l_interval] = QString::fromStdString(MusicNote::semitoneName(MusicNote::semitoneValue(l_close_note - 1)));
+            l_notes[l_start + l_interval] = QString::fromStdString(MusicNote::semitoneName(MusicNote::semitoneValue(l_close_note + 1)));
 
             QwtCompassScaleDraw * l_scale_draw = dynamic_cast<QwtCompassScaleDraw*>(m_compass->scaleDraw());
             myassert(l_scale_draw);

--- a/widgets/pitchcompass/pitchcompassdrawwidget.cpp
+++ b/widgets/pitchcompass/pitchcompassdrawwidget.cpp
@@ -236,8 +236,7 @@ void PitchCompassDrawWidget::updateCompass(double p_time)
         }
         else if (m_mode == PitchCompassView::CompassMode::Mode2)
         {
-            int l_music_key = GData::getUniqueInstance().musicKey();
-            m_compass->setValue(cycle(l_pitch - (double)g_music_key_roots[l_music_key], 12.0) );
+            m_compass->setValue(MusicNote::pitchOffsetInKey(l_pitch));
         }
         else
         {

--- a/widgets/pitchcompass/pitchcompassdrawwidget.cpp
+++ b/widgets/pitchcompass/pitchcompassdrawwidget.cpp
@@ -201,16 +201,10 @@ void PitchCompassDrawWidget::updateMusicScale(int)
 //------------------------------------------------------------------------------
 void PitchCompassDrawWidget::updateCompass(double p_time)
 {
-    const AnalysisData *l_data = nullptr;
-    Channel *l_active_channel = GData::getUniqueInstance().getActiveChannel();
-    
-    if(l_active_channel)
-    {
-        l_data = l_active_channel->dataAtTime(p_time);
-    }
-    
     double l_pitch = 0.0;
-    if(l_data && l_active_channel->hasAnalysisData())
+    Channel *l_active_channel = GData::getUniqueInstance().getActiveChannel();
+
+    if(l_active_channel && l_active_channel->dataAtTime(p_time) && l_active_channel->hasAnalysisData())
     {
         int l_chunk = l_active_channel->currentChunk();
         if(l_chunk >= l_active_channel->totalChunks())

--- a/widgets/pitchcompass/pitchcompassdrawwidget.cpp
+++ b/widgets/pitchcompass/pitchcompassdrawwidget.cpp
@@ -94,9 +94,10 @@ void PitchCompassDrawWidget::setCompassScale(double p_pitch)
         QMap< double, QString > l_notes;
         int l_zero_note = MusicNote::closestNote(p_pitch);
 
-        l_notes[3] = QString::fromStdString(MusicNote::semitoneName(MusicNote::semitoneValue(l_zero_note - 1)));
-        l_notes[0] = QString::fromStdString(MusicNote::semitoneName(MusicNote::semitoneValue(l_zero_note)));
-        l_notes[1] = QString::fromStdString(MusicNote::semitoneName(MusicNote::semitoneValue(l_zero_note + 1)));
+        l_notes[3] = QString::fromStdString(padLabel(MusicNote::semitoneName(MusicNote::semitoneValue(l_zero_note - 1)), -1));
+        l_notes[0] = QString::fromStdString(padLabel(MusicNote::semitoneName(MusicNote::semitoneValue(l_zero_note)), 0));
+        l_notes[1] = QString::fromStdString(padLabel(MusicNote::semitoneName(MusicNote::semitoneValue(l_zero_note + 1)), 1));
+        l_notes[2] = QString::fromStdString(padLabel("", 0));
 
         myassert(l_scale_draw);
         l_scale_draw->setLabelMap(l_notes);
@@ -106,9 +107,10 @@ void PitchCompassDrawWidget::setCompassScale(double p_pitch)
         QMap< double, QString > l_notes;
         int l_close_note = MusicNote::closestNote(p_pitch);
 
-        l_notes[3] = QString::fromStdString(MusicNote::semitoneName(MusicNote::semitoneValue(l_close_note - 1)));
-        l_notes[0] = QString::fromStdString(MusicNote::semitoneName(MusicNote::semitoneValue(l_close_note)));
-        l_notes[1] = QString::fromStdString(MusicNote::semitoneName(MusicNote::semitoneValue(l_close_note + 1)));
+        l_notes[3] = QString::fromStdString(padLabel(MusicNote::semitoneName(MusicNote::semitoneValue(l_close_note - 1)), -1));
+        l_notes[0] = QString::fromStdString(padLabel(MusicNote::semitoneName(MusicNote::semitoneValue(l_close_note)), 0));
+        l_notes[1] = QString::fromStdString(padLabel(MusicNote::semitoneName(MusicNote::semitoneValue(l_close_note + 1)), 1));
+        l_notes[2] = QString::fromStdString(padLabel("", 0));
 
         myassert(l_scale_draw);
         l_scale_draw->setLabelMap(l_notes);
@@ -123,23 +125,8 @@ void PitchCompassDrawWidget::setCompassScale(double p_pitch)
         {
             if(l_music_scale.hasSemitone(l_index))
             {
-                std::string label = MusicNote::semitoneName(cycle(l_index + g_music_key_roots[l_music_key], 12));
-                
-                // Minimize how much the compass resizes due to differences in the lengths of the labels.
-                // Make all of the labels two characters wide.  Don't use regular spaces, since the compass will trim them.
-                if (label.length() < 2)
-                {
-                    if (l_index > 0 && l_index < 6)
-                    {
-                        // Right side of the compass -- pad on the right
-                        label += "\u2002";  // Unicode "En Space"
-                    }
-                    else if (l_index > 6)
-                    {
-                        // Left side of the compass -- pad on the left
-                        label = "\u2002" + label;  // Unicode "En Space"
-                    }
-                }
+                int l_side = (l_index > 0 && l_index < 6) ? 1 : ( (l_index > 6) ? -1 : 0 );
+                std::string label = padLabel(MusicNote::semitoneName(cycle(l_index + g_music_key_roots[l_music_key], 12)), l_side);
                 l_notes[l_index] = QString::fromStdString(label);
             }
             else
@@ -175,6 +162,35 @@ void PitchCompassDrawWidget::setCompassScale(double p_pitch)
         m_compass->setMode(QwtCompass::RotateNeedle);
         m_compass->setMode(QwtCompass::RotateScale);
     }
+}
+
+//------------------------------------------------------------------------------
+// Minimize how much the compass resizes due to differences in the lengths of the labels.
+// Make all of the labels two characters wide.  Don't use regular spaces, since the compass will trim them.
+std::string PitchCompassDrawWidget::padLabel(const std::string & p_label, int p_side)
+{
+    std::string l_label = p_label;
+    
+    if (p_side == 0 && l_label.length() == 0)
+    {
+        // Top or bottom of the compass -- set to two spaces
+        l_label = "\u2002\u2002";  // Unicode "En Space"
+    }
+    else if (l_label.length() < 2)
+    {
+        if (p_side == 1)
+        {
+            // Right side of the compass -- pad on the right
+            l_label += "\u2002";  // Unicode "En Space"
+        }
+        else if (p_side == -1)
+        {
+            // Left side of the compass -- pad on the left
+            l_label = "\u2002" + l_label;  // Unicode "En Space"
+        }
+    }
+    
+    return l_label;
 }
 
 //------------------------------------------------------------------------------

--- a/widgets/pitchcompass/pitchcompassdrawwidget.cpp
+++ b/widgets/pitchcompass/pitchcompassdrawwidget.cpp
@@ -43,6 +43,22 @@ PitchCompassDrawWidget::PitchCompassDrawWidget( QWidget *p_parent
     m_compass->setLineWidth(4);
     m_compass->setFrameShadow(QwtCompass::Sunken);
 
+    if(m_mode == PitchCompassView::CompassMode::Mode0)
+    {
+        m_compass->setMode(QwtCompass::RotateNeedle);
+        m_compass->setScale(36, 5);
+    }
+    else if(m_mode == PitchCompassView::CompassMode::Mode1)
+    {
+        m_compass->setMode(QwtCompass::RotateScale);
+        m_compass->setScale(360, 0);
+    }
+    else if(m_mode == PitchCompassView::CompassMode::Mode2)
+    {
+        m_compass->setMode(QwtCompass::RotateNeedle);
+        m_compass->setScale(0, 12);
+    }
+
     setCompassScale();
 
     m_compass->setNeedle(new QwtCompassMagnetNeedle(QwtCompassMagnetNeedle::ThinStyle));
@@ -75,22 +91,16 @@ void PitchCompassDrawWidget::setCompassScale()
 
     if(m_mode == PitchCompassView::CompassMode::Mode0)
     {
-        m_compass->setMode(QwtCompass::RotateNeedle);
-        m_compass->setScale(36, 5);
     }
     else if(m_mode == PitchCompassView::CompassMode::Mode1)
     {
-        m_compass->setMode(QwtCompass::RotateScale);
-        m_compass->setScale(360, 0);
     }
     else if(m_mode == PitchCompassView::CompassMode::Mode2)
     {
         int l_music_key = GData::getUniqueInstance().musicKey();
         const MusicScale &l_music_scale = MusicScale::getScale(GData::getUniqueInstance().musicScale());
 
-        m_compass->setMode(QwtCompass::RotateNeedle);
         QMap< double, QString > l_notes;
-        m_compass->setScale(0, 12);
         for(int l_index = 0; l_index < 12; l_index++)
         {
             if(l_music_scale.hasSemitone(l_index))

--- a/widgets/pitchcompass/pitchcompassdrawwidget.cpp
+++ b/widgets/pitchcompass/pitchcompassdrawwidget.cpp
@@ -71,20 +71,14 @@ void PitchCompassDrawWidget::resizeEvent(QResizeEvent *)
 //------------------------------------------------------------------------------
 void PitchCompassDrawWidget::setCompassScale()
 {
-#if QWT_VERSION >= 0x060000
     QwtCompassScaleDraw *l_scale_draw = new QwtCompassScaleDraw();
-#endif // QWT_VERSION >= 0x060000
 
     if(m_mode == PitchCompassView::CompassMode::Mode0)
     {
         m_compass->setMode(QwtCompass::RotateNeedle);
-#if QWT_VERSION >= 0x060000
         m_compass->setScale(36, 5);
         // Stepping is now defined by qwt_abstract_slider
         m_compass->setSingleSteps(0);
-#else
-        m_compass->setScale(36, 5, 0);
-#endif // QWT_VERSION >= 0x060000
     }
     else if(m_mode == PitchCompassView::CompassMode::Mode1)
     {
@@ -98,7 +92,6 @@ void PitchCompassDrawWidget::setCompassScale()
 
         m_compass->setMode(QwtCompass::RotateNeedle);
         QMap< double, QString > l_notes;
-#if QWT_VERSION >= 0x060000
         m_compass->setScale(0, 12);
         // Stepping is now defined by qwt_abstract_slider
         m_compass->setSingleSteps(30);
@@ -132,17 +125,8 @@ void PitchCompassDrawWidget::setCompassScale()
             }
         }
         l_scale_draw->setLabelMap(l_notes);
-#else
-        m_compass->setScale(11, 2, 30);
-        for(int l_index = 0; l_index < 12; l_index++)
-        {
-            l_notes[l_index * 30] = MusicNote::semitoneName(cycle(l_index + g_music_key_roots[l_music_key], 12));
-        }
-        m_compass->setLabelMap(l_notes);
-#endif // QWT_VERSION >= 0x060000
     }
 
-#if QWT_VERSION >= 0x060000
     // I assume that y defualt Ticks Labels and backbone where displayed with Qwt 5.x
     l_scale_draw->enableComponent( QwtAbstractScaleDraw::Ticks, true );
     l_scale_draw->enableComponent( QwtAbstractScaleDraw::Labels, true );
@@ -159,9 +143,6 @@ void PitchCompassDrawWidget::setCompassScale()
     // TODO: Is there a cleaner way to do this?
     m_compass->setMode(QwtCompass::RotateScale);
     m_compass->setMode(QwtCompass::RotateNeedle);
-#else
-    m_compass->setScaleTicks(1, 1, 3);
-#endif // QWT_VERSION >= 0x060000
 }
 
 //------------------------------------------------------------------------------
@@ -205,25 +186,17 @@ void PitchCompassDrawWidget::updateCompass(double p_time)
             double l_value = (l_pitch - l_zero_val) * l_interval;
             m_compass->setValue(l_value);
 
-#if QWT_VERSION >= 0x060000
             // With Qwt 6.x the map values should match the scale
             // In mode 0 scale is 36 isntead of 360 so need to divide keys by 10
             unsigned int l_div = 10;
-#else
-            unsigned int l_div = 1;
-#endif // QWT_VERSION >= 0x060000
 
             l_notes[(l_interval * 3 ) / l_div] = QString::fromStdString(MusicNote::semitoneName(toInt(l_zero_val)));
             l_notes[0 / l_div] = QString::fromStdString(MusicNote::semitoneName(toInt(l_zero_val += 2)));
             l_notes[l_interval / l_div] = QString::fromStdString(MusicNote::semitoneName(toInt(l_zero_val)));
 
-#if QWT_VERSION >= 0x060000
             QwtCompassScaleDraw * l_scale_draw = dynamic_cast<QwtCompassScaleDraw*>(m_compass->scaleDraw());
             myassert(l_scale_draw);
             l_scale_draw->setLabelMap(l_notes);
-#else
-            m_compass->setLabelMap(l_notes);
-#endif // QWT_VERSION >= 0x060000
         }
         else if(m_mode == PitchCompassView::CompassMode::Mode1)
         {
@@ -244,13 +217,9 @@ void PitchCompassDrawWidget::updateCompass(double p_time)
             l_notes[l_start - l_interval] = QString::fromStdString(MusicNote::semitoneName(toInt(l_close_pitch - 1)));
             l_notes[l_start + l_interval] = QString::fromStdString(MusicNote::semitoneName(toInt(l_close_pitch + 1)));
 
-#if QWT_VERSION >= 0x060000
             QwtCompassScaleDraw * l_scale_draw = dynamic_cast<QwtCompassScaleDraw*>(m_compass->scaleDraw());
             myassert(l_scale_draw);
             l_scale_draw->setLabelMap(l_notes);
-#else
-            m_compass->setLabelMap(l_notes);
-#endif // QWT_VERSION >= 0x060000
         }
         else if (m_mode == PitchCompassView::CompassMode::Mode2)
         {
@@ -278,13 +247,9 @@ void PitchCompassDrawWidget::blank(bool p_force)
         if(m_mode != PitchCompassView::CompassMode::Mode2)
         {
             QMap< double, QString > l_notes;
-#if QWT_VERSION >= 0x060000
             QwtCompassScaleDraw * l_scale_draw = dynamic_cast<QwtCompassScaleDraw*>(m_compass->scaleDraw());
             myassert(l_scale_draw);
             l_scale_draw->setLabelMap(l_notes);
-#else
-            m_compass->setLabelMap(l_notes);
-#endif // QWT_VERSION >= 0x060000
         }
         m_compass->setValid(false);
         m_blank_count = 1;

--- a/widgets/pitchcompass/pitchcompassdrawwidget.cpp
+++ b/widgets/pitchcompass/pitchcompassdrawwidget.cpp
@@ -46,12 +46,12 @@ PitchCompassDrawWidget::PitchCompassDrawWidget( QWidget *p_parent
     if(m_mode == PitchCompassView::CompassMode::Mode0)
     {
         m_compass->setMode(QwtCompass::RotateNeedle);
-        m_compass->setScale(36, 5);
+        m_compass->setScale(0, 4);
     }
     else if(m_mode == PitchCompassView::CompassMode::Mode1)
     {
         m_compass->setMode(QwtCompass::RotateScale);
-        m_compass->setScale(360, 0);
+        m_compass->setScale(0, 4);
     }
     else if(m_mode == PitchCompassView::CompassMode::Mode2)
     {
@@ -196,23 +196,17 @@ void PitchCompassDrawWidget::updateCompass(double p_time)
     
     if (l_pitch > 0)
     {
-        unsigned int l_interval = 90;
-
         if(m_mode == PitchCompassView::CompassMode::Mode0)
         {
             QMap< double, QString > l_notes;
             int l_zero_note = MusicNote::closestNote(l_pitch);
             double l_zero_pitch = MusicNote::temperedPitch(l_zero_note);
-            double l_value = (l_pitch - l_zero_pitch) * l_interval;
+            double l_value = cycle(l_pitch - l_zero_pitch, 4.0);
             m_compass->setValue(l_value);
 
-            // With Qwt 6.x the map values should match the scale
-            // In mode 0 scale is 36 isntead of 360 so need to divide keys by 10
-            unsigned int l_div = 10;
-
-            l_notes[(l_interval * 3 ) / l_div] = QString::fromStdString(MusicNote::semitoneName(MusicNote::semitoneValue(l_zero_note)));
-            l_notes[0 / l_div] = QString::fromStdString(MusicNote::semitoneName(MusicNote::semitoneValue(l_zero_note += 2)));
-            l_notes[l_interval / l_div] = QString::fromStdString(MusicNote::semitoneName(MusicNote::semitoneValue(l_zero_note)));
+            l_notes[3] = QString::fromStdString(MusicNote::semitoneName(MusicNote::semitoneValue(l_zero_note)));
+            l_notes[0] = QString::fromStdString(MusicNote::semitoneName(MusicNote::semitoneValue(l_zero_note += 2)));
+            l_notes[1] = QString::fromStdString(MusicNote::semitoneName(MusicNote::semitoneValue(l_zero_note)));
 
             QwtCompassScaleDraw * l_scale_draw = dynamic_cast<QwtCompassScaleDraw*>(m_compass->scaleDraw());
             myassert(l_scale_draw);
@@ -223,20 +217,11 @@ void PitchCompassDrawWidget::updateCompass(double p_time)
             QMap< double, QString > l_notes;
             int l_close_note = MusicNote::closestNote(l_pitch);
             double l_close_pitch = MusicNote::temperedPitch(l_close_note);
-            double l_start = toInt((l_close_pitch - l_pitch) * l_interval);
-
-            if(l_start < 0)
-            {
-                l_start += 360;
-            }
-            if(l_start > 360)
-            {
-                l_start = fmod(l_start, 360.0);
-            }
+            double l_start = cycle(l_pitch - l_close_pitch, 4.0);
 
             l_notes[l_start] = QString::fromStdString(MusicNote::semitoneName(MusicNote::semitoneValue(l_close_note)));
-            l_notes[l_start - l_interval] = QString::fromStdString(MusicNote::semitoneName(MusicNote::semitoneValue(l_close_note - 1)));
-            l_notes[l_start + l_interval] = QString::fromStdString(MusicNote::semitoneName(MusicNote::semitoneValue(l_close_note + 1)));
+            l_notes[l_start - 1] = QString::fromStdString(MusicNote::semitoneName(MusicNote::semitoneValue(l_close_note - 1)));
+            l_notes[l_start + 1] = QString::fromStdString(MusicNote::semitoneName(MusicNote::semitoneValue(l_close_note + 1)));
 
             QwtCompassScaleDraw * l_scale_draw = dynamic_cast<QwtCompassScaleDraw*>(m_compass->scaleDraw());
             myassert(l_scale_draw);

--- a/widgets/pitchcompass/pitchcompassdrawwidget.cpp
+++ b/widgets/pitchcompass/pitchcompassdrawwidget.cpp
@@ -180,9 +180,22 @@ void PitchCompassDrawWidget::updateCompass(double p_time)
         l_data = l_active_channel->dataAtTime(p_time);
     }
     
-    if(l_data && l_data->getCorrelation() >= 0.9)
+    double l_pitch = 0.0;
+    if(l_data && l_active_channel->hasAnalysisData())
     {
-        double l_pitch = l_data->getPitch() - GData::getUniqueInstance().semitoneOffset();
+        int l_chunk = l_active_channel->currentChunk();
+        if(l_chunk >= l_active_channel->totalChunks())
+        {
+            l_chunk = l_active_channel->totalChunks() - 1;
+        }
+        if(l_chunk >= 0)
+        {
+            l_pitch = l_active_channel->dataAtChunk(l_chunk)->getPitch();
+        }
+    }
+    
+    if (l_pitch > 0)
+    {
         unsigned int l_interval = 90;
 
         if(m_mode == PitchCompassView::CompassMode::Mode0)

--- a/widgets/pitchcompass/pitchcompassdrawwidget.cpp
+++ b/widgets/pitchcompass/pitchcompassdrawwidget.cpp
@@ -255,13 +255,6 @@ void PitchCompassDrawWidget::blank(bool p_force)
 {
     if(p_force || ++m_blank_count >= 10)
     {
-        if(m_mode != PitchCompassView::CompassMode::Mode2)
-        {
-            QMap< double, QString > l_notes;
-            QwtCompassScaleDraw * l_scale_draw = dynamic_cast<QwtCompassScaleDraw*>(m_compass->scaleDraw());
-            myassert(l_scale_draw);
-            l_scale_draw->setLabelMap(l_notes);
-        }
         m_compass->setValid(false);
         m_blank_count = 1;
     }

--- a/widgets/pitchcompass/pitchcompassdrawwidget.cpp
+++ b/widgets/pitchcompass/pitchcompassdrawwidget.cpp
@@ -165,8 +165,16 @@ void PitchCompassDrawWidget::setCompassScale(double p_pitch)
     // Force the compass to invalidate its cache and redraw.
     // QwtDial::invalidateCache() is a protected member.
     // TODO: Is there a cleaner way to do this?
-    m_compass->setMode(QwtCompass::RotateScale);
-    m_compass->setMode(QwtCompass::RotateNeedle);
+    if (m_mode != PitchCompassView::CompassMode::Mode1)
+    {
+        m_compass->setMode(QwtCompass::RotateScale);
+        m_compass->setMode(QwtCompass::RotateNeedle);
+    }
+    else
+    {
+        m_compass->setMode(QwtCompass::RotateNeedle);
+        m_compass->setMode(QwtCompass::RotateScale);
+    }
 }
 
 //------------------------------------------------------------------------------

--- a/widgets/pitchcompass/pitchcompassdrawwidget.cpp
+++ b/widgets/pitchcompass/pitchcompassdrawwidget.cpp
@@ -77,8 +77,6 @@ void PitchCompassDrawWidget::setCompassScale()
     {
         m_compass->setMode(QwtCompass::RotateNeedle);
         m_compass->setScale(36, 5);
-        // Stepping is now defined by qwt_abstract_slider
-        m_compass->setSingleSteps(0);
     }
     else if(m_mode == PitchCompassView::CompassMode::Mode1)
     {
@@ -93,8 +91,6 @@ void PitchCompassDrawWidget::setCompassScale()
         m_compass->setMode(QwtCompass::RotateNeedle);
         QMap< double, QString > l_notes;
         m_compass->setScale(0, 12);
-        // Stepping is now defined by qwt_abstract_slider
-        m_compass->setSingleSteps(30);
         for(int l_index = 0; l_index < 12; l_index++)
         {
             if(l_music_scale.hasSemitone(l_index))

--- a/widgets/pitchcompass/pitchcompassdrawwidget.cpp
+++ b/widgets/pitchcompass/pitchcompassdrawwidget.cpp
@@ -89,20 +89,7 @@ void PitchCompassDrawWidget::setCompassScale(double p_pitch)
 {
     QwtCompassScaleDraw *l_scale_draw = new QwtCompassScaleDraw();
 
-    if(m_mode == PitchCompassView::CompassMode::Mode0)
-    {
-        QMap< double, QString > l_notes;
-        int l_zero_note = MusicNote::closestNote(p_pitch);
-
-        l_notes[3] = QString::fromStdString(padLabel(MusicNote::semitoneName(MusicNote::semitoneValue(l_zero_note - 1)), -1));
-        l_notes[0] = QString::fromStdString(padLabel(MusicNote::semitoneName(MusicNote::semitoneValue(l_zero_note)), 0));
-        l_notes[1] = QString::fromStdString(padLabel(MusicNote::semitoneName(MusicNote::semitoneValue(l_zero_note + 1)), 1));
-        l_notes[2] = QString::fromStdString(padLabel("", 0));
-
-        myassert(l_scale_draw);
-        l_scale_draw->setLabelMap(l_notes);
-    }
-    else if(m_mode == PitchCompassView::CompassMode::Mode1)
+    if(m_mode == PitchCompassView::CompassMode::Mode0 || m_mode == PitchCompassView::CompassMode::Mode1)
     {
         QMap< double, QString > l_notes;
         int l_close_note = MusicNote::closestNote(p_pitch);
@@ -238,16 +225,7 @@ void PitchCompassDrawWidget::updateCompass(double p_time)
     
     if (l_pitch > 0)
     {
-        if(m_mode == PitchCompassView::CompassMode::Mode0)
-        {
-            setCompassScale(l_pitch);
-            
-            int l_zero_note = MusicNote::closestNote(l_pitch);
-            double l_zero_pitch = MusicNote::temperedPitch(l_zero_note);
-            double l_value = cycle(l_pitch - l_zero_pitch, 4.0);
-            m_compass->setValue(l_value);
-        }
-        else if(m_mode == PitchCompassView::CompassMode::Mode1)
+        if(m_mode == PitchCompassView::CompassMode::Mode0 || m_mode == PitchCompassView::CompassMode::Mode1)
         {
             setCompassScale(l_pitch);
             

--- a/widgets/pitchcompass/pitchcompassdrawwidget.cpp
+++ b/widgets/pitchcompass/pitchcompassdrawwidget.cpp
@@ -85,15 +85,33 @@ void PitchCompassDrawWidget::resizeEvent(QResizeEvent *)
 }
 
 //------------------------------------------------------------------------------
-void PitchCompassDrawWidget::setCompassScale()
+void PitchCompassDrawWidget::setCompassScale(double p_pitch)
 {
     QwtCompassScaleDraw *l_scale_draw = new QwtCompassScaleDraw();
 
     if(m_mode == PitchCompassView::CompassMode::Mode0)
     {
+        QMap< double, QString > l_notes;
+        int l_zero_note = MusicNote::closestNote(p_pitch);
+
+        l_notes[3] = QString::fromStdString(MusicNote::semitoneName(MusicNote::semitoneValue(l_zero_note - 1)));
+        l_notes[0] = QString::fromStdString(MusicNote::semitoneName(MusicNote::semitoneValue(l_zero_note)));
+        l_notes[1] = QString::fromStdString(MusicNote::semitoneName(MusicNote::semitoneValue(l_zero_note + 1)));
+
+        myassert(l_scale_draw);
+        l_scale_draw->setLabelMap(l_notes);
     }
     else if(m_mode == PitchCompassView::CompassMode::Mode1)
     {
+        QMap< double, QString > l_notes;
+        int l_close_note = MusicNote::closestNote(p_pitch);
+
+        l_notes[3] = QString::fromStdString(MusicNote::semitoneName(MusicNote::semitoneValue(l_close_note - 1)));
+        l_notes[0] = QString::fromStdString(MusicNote::semitoneName(MusicNote::semitoneValue(l_close_note)));
+        l_notes[1] = QString::fromStdString(MusicNote::semitoneName(MusicNote::semitoneValue(l_close_note + 1)));
+
+        myassert(l_scale_draw);
+        l_scale_draw->setLabelMap(l_notes);
     }
     else if(m_mode == PitchCompassView::CompassMode::Mode2)
     {
@@ -198,34 +216,21 @@ void PitchCompassDrawWidget::updateCompass(double p_time)
     {
         if(m_mode == PitchCompassView::CompassMode::Mode0)
         {
-            QMap< double, QString > l_notes;
+            setCompassScale(l_pitch);
+            
             int l_zero_note = MusicNote::closestNote(l_pitch);
             double l_zero_pitch = MusicNote::temperedPitch(l_zero_note);
             double l_value = cycle(l_pitch - l_zero_pitch, 4.0);
             m_compass->setValue(l_value);
-
-            l_notes[3] = QString::fromStdString(MusicNote::semitoneName(MusicNote::semitoneValue(l_zero_note)));
-            l_notes[0] = QString::fromStdString(MusicNote::semitoneName(MusicNote::semitoneValue(l_zero_note += 2)));
-            l_notes[1] = QString::fromStdString(MusicNote::semitoneName(MusicNote::semitoneValue(l_zero_note)));
-
-            QwtCompassScaleDraw * l_scale_draw = dynamic_cast<QwtCompassScaleDraw*>(m_compass->scaleDraw());
-            myassert(l_scale_draw);
-            l_scale_draw->setLabelMap(l_notes);
         }
         else if(m_mode == PitchCompassView::CompassMode::Mode1)
         {
-            QMap< double, QString > l_notes;
+            setCompassScale(l_pitch);
+            
             int l_close_note = MusicNote::closestNote(l_pitch);
             double l_close_pitch = MusicNote::temperedPitch(l_close_note);
-            double l_start = cycle(l_pitch - l_close_pitch, 4.0);
-
-            l_notes[l_start] = QString::fromStdString(MusicNote::semitoneName(MusicNote::semitoneValue(l_close_note)));
-            l_notes[l_start - 1] = QString::fromStdString(MusicNote::semitoneName(MusicNote::semitoneValue(l_close_note - 1)));
-            l_notes[l_start + 1] = QString::fromStdString(MusicNote::semitoneName(MusicNote::semitoneValue(l_close_note + 1)));
-
-            QwtCompassScaleDraw * l_scale_draw = dynamic_cast<QwtCompassScaleDraw*>(m_compass->scaleDraw());
-            myassert(l_scale_draw);
-            l_scale_draw->setLabelMap(l_notes);
+            double l_value = cycle(l_pitch - l_close_pitch, 4.0);
+            m_compass->setValue(l_value);
         }
         else if (m_mode == PitchCompassView::CompassMode::Mode2)
         {

--- a/widgets/pitchcompass/pitchcompassdrawwidget.h
+++ b/widgets/pitchcompass/pitchcompassdrawwidget.h
@@ -40,7 +40,7 @@ class PitchCompassDrawWidget: public QWidget
 
   private:
 
-    void setCompassScale();
+    void setCompassScale(double p_pitch = 0.0);
     void blank(bool p_force = false);
 
     QwtCompass * m_compass;

--- a/widgets/pitchcompass/pitchcompassdrawwidget.h
+++ b/widgets/pitchcompass/pitchcompassdrawwidget.h
@@ -24,8 +24,8 @@ class PitchCompassDrawWidget: public QWidget
 
   public:
     PitchCompassDrawWidget( QWidget * p_parent
-                          , const std::string & p_name = ""
-                          , PitchCompassView::CompassMode p_mode = PitchCompassView::CompassMode::Mode2
+                          , const std::string & p_name
+                          , PitchCompassView::CompassMode p_mode
                           );
 
     ~PitchCompassDrawWidget() override;

--- a/widgets/pitchcompass/pitchcompassdrawwidget.h
+++ b/widgets/pitchcompass/pitchcompassdrawwidget.h
@@ -41,6 +41,7 @@ class PitchCompassDrawWidget: public QWidget
   private:
 
     void setCompassScale(double p_pitch = 0.0);
+    std::string padLabel(const std::string & p_label, int p_side);
     void blank(bool p_force = false);
 
     QwtCompass * m_compass;


### PR DESCRIPTION
- Remove code for QWT < 6.0 in `PitchCompassDrawWidget` (it was too broken to fix)
- Remove unnecessary calls to `setSingleSteps()` (the calls had no effect)
- Move one-time config from `PitchCompassDrawWidget::setCompassScale()` to constructor
- Don't use `getCorrelation() >= 0.9` (use same logic as `TunerView`)
- Update compass modes 0 and 1 to use `closestNote()` and `temperedPitch()`
- Change scale for compass modes 0 and 1 to be 0-4
- Move compass label logic from `updateCompass()` to `setCompassScale()`
- Only blank compass needle -- not labels
- Force update of compass for Mode1 correctly
- Add `padLabel()` helper function to pad labels to equal width
- Merge shared code for mode 0 and mode 1
- Remove duplicate default value of `PitchCompassView` mode (don't define it twice)

With these changes, modes 0 and 1 also work:
- Mode 0 is basically the same as the the Chromatic Tuner, but not as nice
- Mode 1 is like Mode 0, but the dial moves instead of the needle
- Mode 2 seems to be the easiest to use, since the labels stay in the same locations

The only way to change modes is to edit the source code.